### PR TITLE
Commands translation for italian

### DIFF
--- a/package.nls.it.json
+++ b/package.nls.it.json
@@ -1,0 +1,10 @@
+{
+	"azure-account.commands.azure": "Azure",
+	"azure-account.commands.login": "Autenticati",
+	"azure-account.commands.logout": "Esci",
+	"azure-account.commands.selectSubscriptions": "Seleziona Iscrizioni",
+	"azure-account.commands.createAccount": "Crea un account",
+	"azure-account.commands.openCloudConsoleLinux": "Apri Bash in Cloud Shell",
+	"azure-account.commands.openCloudConsoleWindows": "Apri PowerShell in Cloud Shell",
+	"azure-account.commands.uploadFileCloudConsole": "Carica alla Cloud Shell"
+}


### PR DESCRIPTION
Added command translation for Italian.

![git](https://user-images.githubusercontent.com/11615441/46361906-1de4bf00-c66f-11e8-8eae-ac9ddbadcb89.gif)
