### PR TITLE
sanitize events from error properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-account",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -43,7 +43,7 @@
     "@types/keytar": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/keytar/-/keytar-4.0.1.tgz",
-      "integrity": "sha1-4s9kBdwzhhQk5ZtnUWxm0s97whs=",
+      "integrity": "sha512-loKBID6UL4QjhD2scuvv6oAPlQ/WAY7aYTDyKlKo7fIgriLS8EZExqT567cHL5CY6si51MRoX1+r3mitD3eYrA==",
       "dev": true
     },
     "@types/node": {
@@ -675,13 +675,14 @@
       }
     },
     "applicationinsights": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.6.tgz",
-      "integrity": "sha512-VQT3kBpJVPw5fCO5n+WUeSx0VHjxFtD7znYbILBlVgOS9/cMDuGFmV2Br3ObzFyZUDGNbEfW36fD1y2/vAiCKw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
+      "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
       "requires": {
+        "cls-hooked": "^4.2.2",
+        "continuation-local-storage": "^3.2.1",
         "diagnostic-channel": "0.2.0",
-        "diagnostic-channel-publishers": "0.2.1",
-        "zone.js": "0.7.6"
+        "diagnostic-channel-publishers": "^0.3.3"
       }
     },
     "aproba": {
@@ -779,10 +780,27 @@
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "requires": {
+        "stack-chain": "^1.3.7"
+      }
+    },
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "requires": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1316,6 +1334,16 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1410,6 +1438,15 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
+    },
+    "continuation-local-storage": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "requires": {
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
+      }
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -1630,9 +1667,9 @@
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.2.1.tgz",
-      "integrity": "sha1-ji1geottef6IC1SLxYzGvrKIxPM="
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
+      "integrity": "sha512-SZ1zMfFiEabf4Qx0Og9V1gMsRoqz3O+5ENkVcNOfI+SMJ3QhQsdEoKX99r0zvreagXot2parPxmrwwUM/ja8ug=="
     },
     "diff": {
       "version": "3.5.0",
@@ -1704,6 +1741,14 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "requires": {
+        "shimmer": "^1.2.0"
       }
     },
     "emojis-list": {
@@ -1950,8 +1995,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1975,15 +2019,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2000,22 +2042,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2146,8 +2185,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2161,7 +2199,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2178,7 +2215,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2187,15 +2223,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2216,7 +2250,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2305,8 +2338,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2320,7 +2352,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2416,8 +2447,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2459,7 +2489,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2481,7 +2510,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2539,15 +2567,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4480,7 +4506,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -4591,6 +4617,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -4827,6 +4858,11 @@
       "requires": {
         "safe-buffer": "^5.1.1"
       }
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "static-extend": {
       "version": "0.1.2",
@@ -5664,11 +5700,11 @@
       }
     },
     "vscode-extension-telemetry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.0.tgz",
-      "integrity": "sha512-WVCnP+uLxlqB6UD98yQNV47mR5Rf79LFxpuZhSPhEf0Sb4tPZed3a63n003/dchhOwyCTCBuNN4n8XKJkLEI1Q==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.5.tgz",
+      "integrity": "sha512-/qTvBV6IJxavF16EWJKbjVRm5YLByAOMg+YRii8y1uyQKl2Ea/SIwyC5/Pxh3NQKHrahp2zL2U6ZW3Z023NjkA==",
       "requires": {
-        "applicationinsights": "1.0.6"
+        "applicationinsights": "1.7.4"
       }
     },
     "vscode-nls": {
@@ -6296,11 +6332,6 @@
       "requires": {
         "camelcase": "^4.1.0"
       }
-    },
-    "zone.js": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.7.6.tgz",
-      "integrity": "sha1-+7w50+AmHQmG8boGMG6zrrDSIAk="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "theme": "dark"
   },
   "enableProposedApi": true,
-  "version": "0.8.9",
+  "version": "0.8.10",
   "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
   "publisher": "ms-vscode",
   "engines": {
@@ -231,7 +231,7 @@
     "request": "2.88.0",
     "request-promise": "4.2.2",
     "semver": "5.6.0",
-    "vscode-extension-telemetry": "0.1.0",
+    "vscode-extension-telemetry": "0.1.5",
     "vscode-nls": "4.0.0",
     "ws": "6.1.0"
   }

--- a/src/azure-account.ts
+++ b/src/azure-account.ts
@@ -18,7 +18,7 @@ import { window, commands, EventEmitter, MessageItem, ExtensionContext, workspac
 import { AzureAccount, AzureSession, AzureLoginStatus, AzureResourceFilter, AzureSubscription } from './azure-account.api';
 import { createCloudConsole } from './cloudConsole';
 import * as codeFlowLogin from './codeFlowLogin';
-import TelemetryReporter from 'vscode-extension-telemetry';
+import { TelemetryReporter } from './telemetry';
 import { TokenResponse } from 'adal-node';
 
 const localize = nls.loadMessageBundle();
@@ -313,7 +313,7 @@ export class AzureLoginHelper {
 			await this.waitForSubscriptions();
 			event.subscriptions = JSON.stringify((await this.subscriptions).map(s => s.subscription.subscriptionId!));
 		}
-		this.reporter.sendTelemetryEvent('login', event);
+		this.reporter.sendSanitizedEvent('login', event);
 	}
 
 	async logout() {

--- a/src/cloudConsole.ts
+++ b/src/cloudConsole.ts
@@ -12,7 +12,7 @@ import * as nls from 'vscode-nls';
 import * as path from 'path';
 import * as cp from 'child_process';
 import * as semver from 'semver';
-import TelemetryReporter from 'vscode-extension-telemetry';
+import { TelemetryReporter } from './telemetry';
 import { TenantDetailsClient } from './tenantDetailsClient';
 import { DeviceTokenCredentials } from 'ms-rest-azure';
 import { ReadStream } from 'fs';
@@ -71,7 +71,7 @@ function sendTelemetryEvent(reporter: TelemetryReporter, outcome: string, messag
 	   }
 	 */
 
-	reporter.sendTelemetryEvent('openCloudConsole', message ? { outcome, message } : { outcome });
+	reporter.sendSanitizedEvent('openCloudConsole', message ? { outcome, message } : { outcome });
 }
 
 async function waitForConnection(this: CloudShell) {

--- a/src/nps.ts
+++ b/src/nps.ts
@@ -7,7 +7,7 @@
 
 import { ExtensionContext, env, window, extensions, Uri } from 'vscode';
 import * as nls from 'vscode-nls';
-import TelemetryReporter from 'vscode-extension-telemetry';
+import { TelemetryReporter } from './telemetry';
 
 const localize = nls.loadMessageBundle();
 
@@ -62,7 +62,7 @@ export function survey({ globalState }: ExtensionContext, reporter: TelemetryRep
 				/* __GDPR__
 					"nps.survey/takeShortSurvey" : {}
 				*/
-				reporter.sendTelemetryEvent('nps.survey/takeShortSurvey');
+				reporter.sendSanitizedEvent('nps.survey/takeShortSurvey');
 				env.openExternal(Uri.parse(`${NPS_SURVEY_URL}?o=${encodeURIComponent(process.platform)}&v=${encodeURIComponent(extensionVersion)}&m=${encodeURIComponent(env.machineId)}`));
 				await globalState.update(IS_CANDIDATE_KEY, false);
 				await globalState.update(SKIP_VERSION_KEY, extensionVersion);
@@ -74,7 +74,7 @@ export function survey({ globalState }: ExtensionContext, reporter: TelemetryRep
 				/* __GDPR__
 					"nps.survey/remindMeLater" : {}
 				*/
-				reporter.sendTelemetryEvent('nps.survey/remindMeLater');
+				reporter.sendSanitizedEvent('nps.survey/remindMeLater');
 				await globalState.update(SESSION_COUNT_KEY, sessionCount - 3);
 			}
 		};
@@ -85,7 +85,7 @@ export function survey({ globalState }: ExtensionContext, reporter: TelemetryRep
 				/* __GDPR__
 					"nps.survey/dontShowAgain" : {}
 				*/
-				reporter.sendTelemetryEvent('nps.survey/dontShowAgain');
+				reporter.sendSanitizedEvent('nps.survey/dontShowAgain');
 				await globalState.update(IS_CANDIDATE_KEY, false);
 				await globalState.update(SKIP_VERSION_KEY, extensionVersion);
 			}
@@ -93,7 +93,7 @@ export function survey({ globalState }: ExtensionContext, reporter: TelemetryRep
 		/* __GDPR__
 			"nps.survey/userAsked" : {}
 		*/
-		reporter.sendTelemetryEvent('nps.survey/userAsked');
+		reporter.sendSanitizedEvent('nps.survey/userAsked');
 		const button = await window.showInformationMessage(localize('azure-account.surveyQuestion', "Do you mind taking a quick feedback survey about the Azure Extensions for VS Code?"), take, remind, never);
 		await (button || remind).run();
 	})().catch(console.error);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -3,12 +3,38 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import TelemetryReporter from 'vscode-extension-telemetry';
+import TReporter from 'vscode-extension-telemetry';
 import { ExtensionContext } from 'vscode';
 
-export function createReporter(context: ExtensionContext) {
-    const extensionPackage = require('../package.json');
-    const reporter = new TelemetryReporter(extensionPackage.name, extensionPackage.version, extensionPackage.aiKey);
+export interface TelemetryReporter {
+    sendSanitizedEvent(eventName: string, properties?: { [key: string]: string; }): void;
+}
+
+const MESSAGE = 'message';
+const PROPS = [MESSAGE];
+
+export function createReporter(context: ExtensionContext): TelemetryReporter {
+    const reporter = new class implements TelemetryReporter {
+        private _reporter: TReporter;
+
+        constructor() {
+            const extensionPackage = require('../package.json');
+            this._reporter = new TReporter(extensionPackage.name, extensionPackage.version, extensionPackage.aiKey, true);
+        }
+
+        sendSanitizedEvent(eventName: string, properties?: { [key: string]: string; } | undefined): void {
+            if (properties && properties[MESSAGE]) {
+                this._reporter.sendTelemetryErrorEvent(eventName, properties, undefined, PROPS);
+            } else {
+                this._reporter.sendTelemetryEvent(eventName, properties);
+            }
+        }
+
+        dispose() {
+            this._reporter.dispose();
+        }
+
+    }
     context.subscriptions.push(reporter);
     return reporter;
 }


### PR DESCRIPTION
Adopt vscode error telemetry 0.1.15 and ensure we declare the `message` property that's classified as `CallStackOrException` as a property to be removed when needed.

I also increased the version of the extension.