### PR TITLE
Add tenant intput box to improve user experience

### DIFF
--- a/src/azure-account.ts
+++ b/src/azure-account.ts
@@ -380,8 +380,6 @@ export class AzureLoginHelper {
 		if (selected) {
 			const config = workspace.getConfiguration('azure');
 			if (config.get('cloud') !== selected.environment.name) {
-				let tenantInputText = commonTenantId;
-				let tenantId;
 				let armUrl;
 				if (selected.environment.name === azureCustomCloud) {
 					armUrl = await window.showInputBox({
@@ -389,15 +387,14 @@ export class AzureLoginHelper {
 						placeHolder: 'https://management.local.azurestack.external',
 						ignoreFocusOut: true
 					});
-					tenantInputText = "Azure Custom Cloud Tenant Id";
 					if (!armUrl) {
 						// directly return when user didn't type in anything or press esc for resourceManagerEndpointUrl inputbox
 						return;
 					}
 				}
-				tenantId = await window.showInputBox({
+				const tenantId = await window.showInputBox({
 					prompt: localize('azure-account.enterTenantId', "Enter the tenant id"),
-					placeHolder: tenantInputText,
+					placeHolder: localize('azure-account.tenantIdPlaceholder', "Enter your tenant id, or '{0}' for the default tenant", commonTenantId),
 					ignoreFocusOut: true});
 				if (tenantId) {
 					if (armUrl) {

--- a/src/azure-account.ts
+++ b/src/azure-account.ts
@@ -397,8 +397,11 @@ export class AzureLoginHelper {
 					} else {
 						return;
 					}
+				} else {
+					// Set tenant Id back to commonTenantId if user isn't using Azure Custom Cloud to avoid unmatched tenant id issue.
+					await config.update('tenant', commonTenantId, getCurrentTarget(config.inspect('tenant')));
 				}
-
+				
 				// if outside of normal range, set ppe setting
 				await config.update('cloud', selected.environment.name, getCurrentTarget(config.inspect('cloud')));
 			}

--- a/src/azure-account.ts
+++ b/src/azure-account.ts
@@ -388,8 +388,8 @@ export class AzureLoginHelper {
 					});
 					if (armUrl) {
 						const tenantId = await window.showInputBox({
-							prompt: localize('azure-account.enterTenantId', "Enter the Tenant Id"),
-							placeHolder: "Tenant Id..",
+							prompt: localize('azure-account.enterTenantId', "Enter the tenant id"),
+							placeHolder: "Tenant Id",
 							ignoreFocusOut: true
 						});
 						if (tenantId) {

--- a/src/azure-account.ts
+++ b/src/azure-account.ts
@@ -401,7 +401,7 @@ export class AzureLoginHelper {
 					// Set tenant Id back to commonTenantId if user isn't using Azure Custom Cloud to avoid unmatched tenant id issue.
 					await config.update('tenant', commonTenantId, getCurrentTarget(config.inspect('tenant')));
 				}
-				
+
 				// if outside of normal range, set ppe setting
 				await config.update('cloud', selected.environment.name, getCurrentTarget(config.inspect('cloud')));
 			}

--- a/src/azure-account.ts
+++ b/src/azure-account.ts
@@ -386,14 +386,18 @@ export class AzureLoginHelper {
 						placeHolder: 'https://management.local.azurestack.external',
 						ignoreFocusOut: true
 					});
-					const tenantId = await window.showInputBox({
-						prompt: localize('azure-account.enterTenantId', "Enter the Tenant Id"),
-						placeHolder: "Please enter your tenant Id here",
-						ignoreFocusOut: true
-					});
 					if (armUrl) {
-						await config.update(customCloudArmUrlKey, armUrl, getCurrentTarget(config.inspect(customCloudArmUrlKey)));
-						await config.update('tenant', tenantId, getCurrentTarget(config.inspect('tenant')));
+						const tenantId = await window.showInputBox({
+							prompt: localize('azure-account.enterTenantId', "Enter the Tenant Id"),
+							placeHolder: "Tenant Id..",
+							ignoreFocusOut: true
+						});
+						if (tenantId) {
+							await config.update(customCloudArmUrlKey, armUrl, getCurrentTarget(config.inspect(customCloudArmUrlKey)));
+							await config.update('tenant', tenantId, getCurrentTarget(config.inspect('tenant')));
+						} else {
+							return;
+						}
 					} else {
 						return;
 					}

--- a/src/azure-account.ts
+++ b/src/azure-account.ts
@@ -386,8 +386,14 @@ export class AzureLoginHelper {
 						placeHolder: 'https://management.local.azurestack.external',
 						ignoreFocusOut: true
 					});
+					const tenantId = await window.showInputBox({
+						prompt: localize('azure-account.enterTenantId', "Enter the Tenant Id"),
+						placeHolder: "Please enter your tenant Id here",
+						ignoreFocusOut: true
+					});
 					if (armUrl) {
 						await config.update(customCloudArmUrlKey, armUrl, getCurrentTarget(config.inspect(customCloudArmUrlKey)));
+						await config.update('tenant', tenantId, getCurrentTarget(config.inspect('tenant')));
 					} else {
 						return;
 					}


### PR DESCRIPTION
Hey @RMacfarlane, this PR add another inputbox for tenant Id when users are trying to login to Azure Custom Cloud without setting parameters in usersetting.json. Then users don't need to set tenant Id separately in user setting, we believe it would improve user's using experience. 