### PR TITLE
Add 'Sign In with Device Code' for MSAL

### DIFF
--- a/src/login/AuthProviderBase.ts
+++ b/src/login/AuthProviderBase.ts
@@ -10,9 +10,11 @@ import { AccountInfo } from "@azure/msal-node";
 import { randomBytes } from "crypto";
 import { ServerResponse } from "http";
 import { DeviceTokenCredentials } from "ms-rest-azure";
-import { env, UIKind } from "vscode";
+import { env, MessageItem, UIKind, window } from "vscode";
 import { AzureAccountExtensionApi, AzureSession } from "../azure-account.api";
 import { redirectUrlAAD, redirectUrlADFS } from "../constants";
+import { localize } from "../utils/localize";
+import { openUri } from "../utils/openUri";
 import { ISubscriptionCache } from "./AzureLoginHelper";
 import { AzureSessionInternal } from "./AzureSessionInternal";
 import { getEnvironments } from "./environments";
@@ -126,5 +128,16 @@ export abstract class AuthProviderBase<TLoginResult> {
 		}
 
 		return sessions;
+	}
+
+	protected async showDeviceCodeMessage(message: string, userCode: string, verificationUrl: string): Promise<void> {
+		const copyAndOpen: MessageItem = { title: localize('azure-account.copyAndOpen', "Copy & Open") };
+		const response: MessageItem | undefined = await window.showInformationMessage(message, copyAndOpen);
+		if (response === copyAndOpen) {
+			void env.clipboard.writeText(userCode);
+			await openUri(verificationUrl);
+		} else {
+			return Promise.reject('user canceled');
+		}
 	}
 }

--- a/src/login/adal/AdalAuthProvider.ts
+++ b/src/login/adal/AdalAuthProvider.ts
@@ -16,7 +16,7 @@ import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
 import { timeout } from "../../utils/timeUtils";
 import { AbstractCredentials, AbstractCredentials2, AuthProviderBase } from "../AuthProviderBase";
-import { getCallbackEnvironment, getUserCode, parseQuery, showDeviceCodeMessage, UriEventHandler } from "./login";
+import { getCallbackEnvironment, getUserCode, parseQuery, UriEventHandler } from "./login";
 import { addTokenToCache, clearTokenCache, deleteRefreshToken, getStoredCredentials, getTokenResponse, getTokensFromToken, getTokenWithAuthorizationCode, ProxyTokenCache, storeRefreshToken, tokenFromRefreshToken } from "./tokens";
 
 const staticEnvironmentNames: string[] = [
@@ -87,7 +87,7 @@ export class AdalAuthProvider extends AuthProviderBase<TokenResponse[]> {
 
 	public async loginWithDeviceCode(environment: Environment, tenantId: string): Promise<TokenResponse[]> {
 		const userCode: UserCodeInfo = await getUserCode(environment, tenantId);
-		const messageTask: Promise<void> = showDeviceCodeMessage(userCode);
+		const messageTask: Promise<void> = this.showDeviceCodeMessage(userCode.message, userCode.userCode, userCode.verificationUrl);
 		const tokenResponseTask: Promise<TokenResponse> = getTokenResponse(environment, tenantId, userCode);
 		const tokenResponse: TokenResponse = await Promise.race([tokenResponseTask, messageTask.then(() => Promise.race([tokenResponseTask, timeout(3 * 60 * 1000)]))]); // 3 minutes
 

--- a/src/login/adal/login.ts
+++ b/src/login/adal/login.ts
@@ -7,11 +7,10 @@ import { Environment } from "@azure/ms-rest-azure-env";
 // eslint-disable-next-line import/no-internal-modules
 import { AuthenticationContext, MemoryCache } from "@azure/ms-rest-nodeauth/node_modules/adal-node";
 import { UserCodeInfo } from "adal-node";
-import { env, EventEmitter, MessageItem, Uri, UriHandler, window } from "vscode";
+import { EventEmitter, Uri, UriHandler } from "vscode";
 import { clientId } from "../../constants";
 import { AzureLoginError } from "../../errors";
 import { localize } from "../../utils/localize";
-import { openUri } from "../../utils/openUri";
 
 export class UriEventHandler extends EventEmitter<Uri> implements UriHandler {
 	public handleUri(uri: Uri): void {
@@ -45,17 +44,6 @@ export function getCallbackEnvironment(callbackUri: Uri): string {
 			return 'vsocanary,';
 		default:
 			return '';
-	}
-}
-
-export async function showDeviceCodeMessage(userCode: UserCodeInfo): Promise<void> {
-	const copyAndOpen: MessageItem = { title: localize('azure-account.copyAndOpen', "Copy & Open") };
-	const response: MessageItem | undefined = await window.showInformationMessage(userCode.message, copyAndOpen);
-	if (response === copyAndOpen) {
-		void env.clipboard.writeText(userCode.userCode);
-		await openUri(userCode.verificationUrl);
-	} else {
-		return Promise.reject('user canceled');
 	}
 }
 

--- a/src/login/msal/MsalAuthProvider.ts
+++ b/src/login/msal/MsalAuthProvider.ts
@@ -5,6 +5,7 @@
 
 import { Environment } from "@azure/ms-rest-azure-env";
 import { AzureIdentityCredentialAdapter } from '@azure/ms-rest-js';
+import { DeviceCodeResponse } from "@azure/msal-common";
 import { AccountInfo, AuthenticationResult, Configuration, LogLevel, PublicClientApplication, TokenCache } from "@azure/msal-node";
 import { AzureSession } from "../../azure-account.api";
 import { clientId, msalScopes } from "../../constants";
@@ -49,14 +50,23 @@ export class MsalAuthProvider extends AuthProviderBase<AuthenticationResult> {
 		});
 
 		if (!authResult) {
-			throw new Error(localize('azure-account.msalAuthFailed', 'MSAL authentication failed.'));
+			throw new Error(localize('azure-account.msalAuthCodeFailed', 'MSAL authentication code login failed.'));
 		}
 
 		return authResult;
 	}
 
 	public async loginWithDeviceCode(): Promise<AuthenticationResult> {
-		throw new Error('"Login With Device Code" not implemented for MSAL.');
+		const authResult: AuthenticationResult | null = await this.publicClientApp.acquireTokenByDeviceCode({
+			scopes: msalScopes,
+			deviceCodeCallback: (response: DeviceCodeResponse) => this.showDeviceCodeMessage(response.message, response.userCode, response.verificationUri)
+		});
+
+		if (!authResult) {
+			throw new Error(localize('azure-account.msalDeviceCodeFailed', 'MSAL device code login failed.'));
+		}
+
+		return authResult;
 	}
 
 	public async loginSilent(): Promise<AuthenticationResult> {


### PR DESCRIPTION
The device code authentication flow isn't supported for Microsoft employee accounts: https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/3951#issuecomment-915659897. But it works in cases where the "require managed device" grant control is disabled.

There was some confusion earlier when I thought I got this working for Microsoft employee accounts. I was using the client ID (configured with preauthorization) from the [device code sample](https://github.com/AzureAD/microsoft-authentication-library-for-js/tree/dev/samples/msal-node-samples/device-code) along with a pre-production authority (again, from the sample code). And under those conditions it works.