### PR TITLE
Show a notification after a timeout reminding users to enable popups in Codespaces

### DIFF
--- a/src/login/AuthProviderBase.ts
+++ b/src/login/AuthProviderBase.ts
@@ -126,7 +126,12 @@ export abstract class AuthProviderBase<TLoginResult> {
 			}, 1000 * 60 * 5)
 		});
 
-		return await Promise.race([exchangeCodeForToken<TLoginResult>(this, clientId, environment, tenantId, redirectUrlAAD, state), timeoutPromise]);
+		const popupTimeout = setTimeout(() => {
+			const checkIfPopupsBlocked = localize('azure-account.checkIfPopupsBlocked', 'If the login window has not opened yet, ensure pop-ups are enabled for your browser.');
+			void window.showInformationMessage(checkIfPopupsBlocked);
+		}, 15*1000);
+
+		return await Promise.race([exchangeCodeForToken<TLoginResult>(this, clientId, environment, tenantId, redirectUrlAAD, state, popupTimeout), timeoutPromise]);
 	}
 
 	public async initializeSessions(cache: ISubscriptionCache, api: AzureAccountExtensionApi): Promise<Record<string, AzureSession>> {

--- a/src/login/AuthProviderBase.ts
+++ b/src/login/AuthProviderBase.ts
@@ -127,7 +127,7 @@ export abstract class AuthProviderBase<TLoginResult> {
 		});
 
 		const popupTimeout = setTimeout(() => {
-			const checkIfPopupsBlocked = localize('azure-account.checkIfPopupsBlocked', 'If the login window has not opened yet, ensure pop-ups are enabled for your browser.');
+			const checkIfPopupsBlocked = localize('azure-account.checkIfPopupsBlocked', 'If the sign in window has not opened yet, ensure pop-ups are enabled for your browser.');
 			void window.showInformationMessage(checkIfPopupsBlocked);
 		}, 15*1000);
 

--- a/src/login/exchangeCodeForToken.ts
+++ b/src/login/exchangeCodeForToken.ts
@@ -14,11 +14,13 @@ export class UriEventHandler extends EventEmitter<Uri> implements UriHandler {
 	}
 }
 
-export async function exchangeCodeForToken<TLoginResult>(authProvider: AuthProviderBase<TLoginResult>, clientId: string, environment: Environment, tenantId: string, callbackUri: string, state: string): Promise<TLoginResult> {
+export async function exchangeCodeForToken<TLoginResult>(authProvider: AuthProviderBase<TLoginResult>, clientId: string, environment: Environment, tenantId: string, callbackUri: string, state: string, popupTimeout: NodeJS.Timeout): Promise<TLoginResult> {
 	let uriEventListener: Disposable;
 	return new Promise((resolve: (value: TLoginResult) => void , reject) => {
 		uriEventListener = ext.uriEventHandler.event(async (uri: Uri) => {
 			try {
+				clearTimeout(popupTimeout);
+
 				/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 				const query = parseQuery(uri);
 				const code = query.code;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/311

This notification is shown 15 seconds after starting the sign in process unless it completes in that time:
![Screen Shot 2021-10-05 at 5 01 27 PM](https://user-images.githubusercontent.com/22795803/136120014-5cdbb4ec-ba9c-45f0-9be9-bc88ef88f265.png)

But the problem is that the notification will show up after 15sec even if the login window opened successfully. I think its still better to have the reminder to check pop-ups even if its shown extraneously sometimes but I'm open to other thoughts on it.
