### PR TITLE
Call `registerUIExtensionVariables` before creating experimentation service

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,12 +13,18 @@ import { basename } from 'path';
 import { shells, OSes } from './cloudConsole';
 import { survey } from './nps';
 import { ext } from './extensionVariables';
-import { createExperimentationService } from 'vscode-azureextensionui';
+import { createAzExtOutputChannel, createExperimentationService, registerUIExtensionVariables } from 'vscode-azureextensionui';
 
 const localize = nls.loadMessageBundle();
 const enableLogging = false;
 
 export async function activate(context: ExtensionContext) {
+	ext.context = context;
+	ext.outputChannel = createAzExtOutputChannel('Azure Account', 'azure');
+	context.subscriptions.push(ext.outputChannel);
+
+	registerUIExtensionVariables(ext);
+
 	ext.experimentationService = await createExperimentationService(context);
 
 	await migrateEnvironmentSetting();

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -3,8 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IExperimentationServiceAdapter } from "vscode-azureextensionui";
+import { ExtensionContext } from "vscode";
+import { IAzExtOutputChannel, IExperimentationServiceAdapter } from "vscode-azureextensionui";
 
 export namespace ext {
+    export let context: ExtensionContext;
+    export let outputChannel: IAzExtOutputChannel;
     export let experimentationService: IExperimentationServiceAdapter;
 }


### PR DESCRIPTION
I neglected to do this in https://github.com/microsoft/vscode-azure-account/pull/330 and the experimentation service wasn't created properly. 

Here's what `experimentationService` looked like before this change:

![Screen Shot 2021-10-14 at 12 18 24 PM](https://user-images.githubusercontent.com/22795803/137381762-6db81a47-b582-4a3c-b18c-30f29284cd89.png)

And here's the properly created object with this change:

![Screen Shot 2021-10-14 at 12 20 23 PM](https://user-images.githubusercontent.com/22795803/137382004-d27500aa-54c7-4de9-8fe1-9a5ff4e10034.png)

`registerUIExtensionVariables` requires that the extension variables include `context` and `outputChannel` so I added those as well.