### PR TITLE
Remove legacy API check in cloud console

### DIFF
--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -22,7 +22,6 @@ import { tokenFromRefreshToken } from '../login/adal/tokens';
 import { TelemetryReporter } from '../telemetry';
 import { localize } from '../utils/localize';
 import { Deferred } from '../utils/promiseUtils';
-import { getAuthLibrary } from '../utils/settingUtils';
 import { AccessTokens, connectTerminal, ConsoleUris, Errors, getUserSettings, provisionConsole, resetConsole, Size, UserSettings } from './cloudConsoleLauncher';
 import { createServer, Queue, readJSON, Server } from './ipc';
 
@@ -172,15 +171,7 @@ function getUploadFile(tokens: Promise<AccessTokens>, uris: Promise<ConsoleUris>
 }
 
 export const shells: CloudShell[] = [];
-export function createCloudConsole(api: AzureAccountExtensionApi, reporter: TelemetryReporter, osName: OSName, isLegacyApi?: boolean): CloudShell | undefined {
-	if (!isLegacyApi) {
-		void window.showWarningMessage('Cloud console requires using the legacy API.');
-		return;
-	} else if (getAuthLibrary() !== 'ADAL') {
-		void window.showWarningMessage('Cloud console requires authenticating with ADAL.');
-		return;
-	}
-
+export function createCloudConsole(api: AzureAccountExtensionApi, reporter: TelemetryReporter, osName: OSName): CloudShell {
 	const os: OS = OSes[osName];
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let liveServerQueue: Queue<any> | undefined;

--- a/src/login/AzureAccountExtensionApi.ts
+++ b/src/login/AzureAccountExtensionApi.ts
@@ -70,9 +70,9 @@ export class AzureAccountExtensionApi implements types.AzureAccountExtensionApi 
 		return true;
 	}
 
-	public createCloudShell(os: OSName, isLegacyApi?: boolean): types.CloudShell {
+	public createCloudShell(os: OSName): types.CloudShell {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return createCloudConsole(this, this.azureLoginHelper.reporter, os, isLegacyApi)!;
+		return createCloudConsole(this, this.azureLoginHelper.reporter, os)!;
 	}
 
 	private sendIsLegacyApiTelemetry(eventName: string, isLegacyApi?: boolean): void {

--- a/src/login/AzureAccountExtensionLegacyApi.ts
+++ b/src/login/AzureAccountExtensionLegacyApi.ts
@@ -50,6 +50,6 @@ export class AzureAccountExtensionLegacyApi implements legacyTypes.AzureAccount 
 	}
 
 	public createCloudShell(os: OSName): legacyTypes.CloudShell {
-		return <legacyTypes.CloudShell>this.api.createCloudShell(os, true);
+		return <legacyTypes.CloudShell>this.api.createCloudShell(os);
 	}
 }


### PR DESCRIPTION
The code I'm removing here was never meant to be permanent; I was keeping it around until cloudConsole.ts was updated to use MSAL. That update is still blocked by the ICM I have open. I decided to remove this stuff anyway because it got in the way of me working on https://github.com/microsoft/vscode-azure-account/issues/274 and because we already throw this error if you try to use the cloud console with MSAL:

<img width="641" alt="Screen Shot 2021-10-25 at 6 38 54 PM" src="https://user-images.githubusercontent.com/22795803/138797809-764f6c1e-fefa-4f71-940d-fa683e8a4a52.png">

