### PR TITLE
Provide legacy scope when creating `AzureIdentityCredentialAdapter`

### DIFF
--- a/src/login/msal/MsalAuthProvider.ts
+++ b/src/login/msal/MsalAuthProvider.ts
@@ -93,8 +93,9 @@ export class MsalAuthProvider extends AuthProviderBase<AuthenticationResult> {
 	}
 
 	public getCredentials2(_env: Environment, _userId: string, _tenantId: string, accountInfo?: AccountInfo): AbstractCredentials2 {
+		// The Azure Functions & App Service API endpoints don't accept the default scope (audience) provided by `AzureIdentityCredentialAdapter` so provide the legacy scope
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return new AzureIdentityCredentialAdapter(new PublicClientCredential(this.publicClientApp, accountInfo!));
+		return new AzureIdentityCredentialAdapter(new PublicClientCredential(this.publicClientApp, accountInfo!), 'https://management.core.windows.net/.default');
 	}
 
 	public async updateSessions(environment: Environment, loginResult: AuthenticationResult, sessions: AzureSession[]): Promise<void> {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/315

This one was a long time in the making. The above issue was happening because the Azure Functions and App Service API endpoints don't accept the "https://management.azure.com/.default" audience. This is a problem because `@azure/ms-rest-js` (which we use to create credentials) passes along "https://management.azure.com/.default" by default as an MSAL scope. This then becomes the "audience" field in the token sent to the functions/app service resource. 

There was never a problem with ADAL because with that library we use `@azure/ms-rest-nodeauth` which sends the "https://management.core.windows.net/.default" audience when making requests. That audience is accepted by the functions/app service API. 

So the workaround here is to explicitly provide the working audience "https://management.core.windows.net/.default" when authenticating with MSAL 🎉