### PR TITLE
Adopt VS Code's terminal profile API for cloud shell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
                 "webpack-cli": "^4.5.0"
             },
             "engines": {
-                "vscode": "^1.53.0"
+                "vscode": "^1.58.0"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -8590,7 +8590,7 @@
         },
         "node_modules/safe-regex": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "dependencies": {
@@ -9094,6 +9094,11 @@
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.0.2",
                 "tweetnacl": "~0.14.0"
+            },
+            "bin": {
+                "sshpk-conv": "bin/sshpk-conv",
+                "sshpk-sign": "bin/sshpk-sign",
+                "sshpk-verify": "bin/sshpk-verify"
             },
             "engines": {
                 "node": ">=0.10.0"
@@ -18313,7 +18318,7 @@
         },
         "safe-regex": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "publisher": "ms-vscode",
     "engines": {
-        "vscode": "^1.53.0"
+        "vscode": "^1.58.0"
     },
     "categories": [
         "Azure"
@@ -31,10 +31,10 @@
         "onCommand:azure-account.loginToCloud",
         "onCommand:azure-account.loginWithDeviceCode",
         "onCommand:azure-account.logout",
-        "onCommand:azure-account.openCloudConsoleLinux",
-        "onCommand:azure-account.openCloudConsoleWindows",
         "onCommand:azure-account.selectSubscriptions",
-        "onCommand:azure-account.uploadFileCloudConsole"
+        "onCommand:azure-account.uploadFileCloudConsole",
+        "onTerminalProfile:azure-account.cloudShellBash",
+        "onTerminalProfile:azure-account.cloudShellPowerShell"
     ],
     "main": "./main",
     "contributes": {
@@ -65,16 +65,6 @@
                 "category": "%azure-account.commands.azure%"
             },
             {
-                "command": "azure-account.openCloudConsoleLinux",
-                "title": "%azure-account.commands.openCloudConsoleLinux%",
-                "category": "%azure-account.commands.azure%"
-            },
-            {
-                "command": "azure-account.openCloudConsoleWindows",
-                "title": "%azure-account.commands.openCloudConsoleWindows%",
-                "category": "%azure-account.commands.azure%"
-            },
-            {
                 "command": "azure-account.selectSubscriptions",
                 "title": "%azure-account.commands.selectSubscriptions%",
                 "category": "%azure-account.commands.azure%"
@@ -98,6 +88,20 @@
                     "command": "azure-account.uploadFileCloudConsole",
                     "when": "resourceScheme == file && openCloudConsoleCount && openCloudConsoleCount != 0",
                     "group": "999_cloudConsole"
+                }
+            ]
+        },
+        "terminal": {
+            "profiles": [
+                {
+                    "title": "%azure-account.cloudShellBash%",
+                    "id": "azure-account.cloudShellBash",
+                    "icon": "azure"
+                },
+                {
+                    "title": "%azure-account.cloudShellPowerShell%",
+                    "id": "azure-account.cloudShellPowerShell",
+                    "icon": "azure"
                 }
             ]
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -5,8 +5,8 @@
     "azure-account.commands.loginToCloud": "Sign In to Azure Cloud",
     "azure-account.commands.loginWithDeviceCode": "Sign In with Device Code",
     "azure-account.commands.logout": "Sign Out",
-    "azure-account.commands.openCloudConsoleLinux": "Open Bash in Cloud Shell",
-    "azure-account.commands.openCloudConsoleWindows": "Open PowerShell in Cloud Shell",
     "azure-account.commands.selectSubscriptions": "Select Subscriptions",
-    "azure-account.commands.uploadFileCloudConsole": "Upload to Cloud Shell"
+    "azure-account.commands.uploadFileCloudConsole": "Upload to Cloud Shell",
+    "azure-account.cloudShellBash": "Azure Cloud Shell (Bash)",
+    "azure-account.cloudShellPowerShell": "Azure Cloud Shell (PowerShell)"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,4 +1,6 @@
 {
+    "azure-account.cloudShellBash": "Azure Cloud Shell (Bash)",
+    "azure-account.cloudShellPowerShell": "Azure Cloud Shell (PowerShell)",
     "azure-account.commands.azure": "Azure",
     "azure-account.commands.createAccount": "Create an Account",
     "azure-account.commands.login": "Sign In",
@@ -6,7 +8,5 @@
     "azure-account.commands.loginWithDeviceCode": "Sign In with Device Code",
     "azure-account.commands.logout": "Sign Out",
     "azure-account.commands.selectSubscriptions": "Select Subscriptions",
-    "azure-account.commands.uploadFileCloudConsole": "Upload to Cloud Shell",
-    "azure-account.cloudShellBash": "Azure Cloud Shell (Bash)",
-    "azure-account.cloudShellPowerShell": "Azure Cloud Shell (PowerShell)"
+    "azure-account.commands.uploadFileCloudConsole": "Upload to Cloud Shell"
 }

--- a/src/cloudConsole/CloudShellInternal.ts
+++ b/src/cloudConsole/CloudShellInternal.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Terminal, TerminalProfile } from "vscode";
+import { CloudShell, CloudShellStatus } from "../azure-account.api";
+
+export interface CloudShellInternal extends Omit<CloudShell, 'terminal'> {
+	status: CloudShellStatus;
+	terminal?: Promise<Terminal>;
+	terminalProfile?: Promise<TerminalProfile>;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { CancellationToken, commands, ConfigurationTarget, env, ExtensionContext
 import { createApiProvider, createAzExtOutputChannel, createExperimentationService, registerUIExtensionVariables } from 'vscode-azureextensionui';
 import { AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { AzureAccountExtensionApi } from './azure-account.api';
-import { createCloudConsole, OSes, shells } from './cloudConsole/cloudConsole';
+import { createCloudConsole, OSes, OSName, shells } from './cloudConsole/cloudConsole';
 import { cloudSetting, displayName, extensionPrefix, showSignedInEmailSetting } from './constants';
 import { ext } from './extensionVariables';
 import { AzureLoginHelper } from './login/AzureLoginHelper';
@@ -81,6 +81,14 @@ async function migrateEnvironmentSetting() {
 	await migrateSetting('AzureChina', 'AzureChinaCloud');
 }
 
+function cloudConsole(api: AzureAccountExtensionApi, os: OSName) {
+	const shell = api.createCloudShell(os);
+	if (shell) {
+		void shell.terminal.then(terminal => terminal.show());
+		return shell;
+	}
+}
+
 function uploadFile(api: AzureAccountExtensionApi, uri?: Uri) {
 	(async () => {
 		let shell = shells[0];
@@ -90,7 +98,7 @@ function uploadFile(api: AzureAccountExtensionApi, uri?: Uri) {
 				return;
 			}
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			shell = api.createCloudShell(shellName === OSes.Linux.shellName ? 'Linux' : 'Windows')!;
+			shell = cloudConsole(api, shellName === OSes.Linux.shellName ? 'Linux' : 'Windows')!;
 		}
 		if (!uri) {
 			uri = (await window.showOpenDialog({}) || [])[0];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,11 +5,11 @@
 
 import { createReadStream } from 'fs';
 import { basename } from 'path';
-import { commands, ConfigurationTarget, env, ExtensionContext, ProgressLocation, Uri, window, workspace, WorkspaceConfiguration } from 'vscode';
+import { CancellationToken, commands, ConfigurationTarget, env, ExtensionContext, ProgressLocation, Uri, window, workspace, WorkspaceConfiguration } from 'vscode';
 import { createApiProvider, createAzExtOutputChannel, createExperimentationService, registerUIExtensionVariables } from 'vscode-azureextensionui';
 import { AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { AzureAccountExtensionApi } from './azure-account.api';
-import { OSes, OSName, shells } from './cloudConsole/cloudConsole';
+import { createCloudConsole, OSes, shells } from './cloudConsole/cloudConsole';
 import { cloudSetting, displayName, extensionPrefix, showSignedInEmailSetting } from './constants';
 import { ext } from './extensionVariables';
 import { AzureLoginHelper } from './login/AzureLoginHelper';
@@ -41,9 +41,19 @@ export async function activateInternal(context: ExtensionContext, perfStats: { l
 	}
 	context.subscriptions.push(createStatusBarItem(context, azureLoginHelper.api));
 	context.subscriptions.push(commands.registerCommand('azure-account.createAccount', createAccount));
-	context.subscriptions.push(commands.registerCommand('azure-account.openCloudConsoleLinux', () => cloudConsole(azureLoginHelper.api, 'Linux')));
-	context.subscriptions.push(commands.registerCommand('azure-account.openCloudConsoleWindows', () => cloudConsole(azureLoginHelper.api, 'Windows')));
 	context.subscriptions.push(commands.registerCommand('azure-account.uploadFileCloudConsole', uri => uploadFile(azureLoginHelper.api, uri)));
+
+	window.registerTerminalProfileProvider('azure-account.cloudShellBash', {
+		provideTerminalProfile: (token: CancellationToken) => {
+			return createCloudConsole(azureLoginHelper.api, reporter, 'Linux', token).terminalProfile;
+		}
+	});
+	window.registerTerminalProfileProvider('azure-account.cloudShellPowerShell', {
+		provideTerminalProfile: (token: CancellationToken) => {
+			return createCloudConsole(azureLoginHelper.api, reporter, 'Windows', token).terminalProfile;
+		}
+	});
+
 	survey(context, reporter);
 
 	reporter.sendSanitizedEvent('activate', { 'activationTime': String((perfStats.loadEndTime - perfStats.loadStartTime) / 1000) });
@@ -71,14 +81,6 @@ async function migrateEnvironmentSetting() {
 	await migrateSetting('AzureChina', 'AzureChinaCloud');
 }
 
-function cloudConsole(api: AzureAccountExtensionApi, os: OSName) {
-	const shell = api.createCloudShell(os);
-	if (shell) {
-		void shell.terminal.then(terminal => terminal.show());
-		return shell;
-	}
-}
-
 function uploadFile(api: AzureAccountExtensionApi, uri?: Uri) {
 	(async () => {
 		let shell = shells[0];
@@ -88,7 +90,7 @@ function uploadFile(api: AzureAccountExtensionApi, uri?: Uri) {
 				return;
 			}
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			shell = cloudConsole(api, shellName === OSes.Linux.shellName ? 'Linux' : 'Windows')!;
+			shell = api.createCloudShell(shellName === OSes.Linux.shellName ? 'Linux' : 'Windows')!;
 		}
 		if (!uri) {
 			uri = (await window.showOpenDialog({}) || [])[0];

--- a/src/login/AzureAccountExtensionApi.ts
+++ b/src/login/AzureAccountExtensionApi.ts
@@ -71,8 +71,7 @@ export class AzureAccountExtensionApi implements types.AzureAccountExtensionApi 
 	}
 
 	public createCloudShell(os: OSName): types.CloudShell {
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return createCloudConsole(this, this.azureLoginHelper.reporter, os)!;
+		return <types.CloudShell>createCloudConsole(this, this.azureLoginHelper.reporter, os);
 	}
 
 	private sendIsLegacyApiTelemetry(eventName: string, isLegacyApi?: boolean): void {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/274

In the extension API we expose a `Terminal` object which is what drove the cloud shell feature before the new `TerminalProfile` was added. This change maintains backwards compatibility by creating a `Terminal` if the entry point is the API and `TerminalProfile` if the entry point it the terminal profile provider (the 'terminal' pane in VS Code).

The difference between `Terminal` and `TerminalProfile` is that `Terminal` exposes all the intimate details about a terminal such as the ability to send text to it while `TerminalProfile` just defines how a terminal will be launched.