### PR TITLE
Update launch configuration for debugging extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Extension",
+            "name": "Launch Extension (webpack)",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
@@ -12,7 +12,12 @@
             ],
             "outFiles": [
                 "${workspaceFolder}/dist/**/*.js"
-            ]
+            ],
+            "preLaunchTask": "${defaultBuildTask}",
+            "env": {
+                "DEBUGTELEMETRY": "v",
+                "NODE_DEBUG": ""
+            }
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
     "tasks": [
         {
             "type": "npm",
-            "script": "watch",
+            "script": "webpack",
             "problemMatcher": "$tsc-watch",
             "isBackground": true,
             "presentation": {

--- a/package.json
+++ b/package.json
@@ -223,11 +223,11 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "rimraf dist && webpack --mode production",
+        "vscode:prepublish": "rimraf dist && npm run build && webpack --mode production",
         "build": "tsc",
         "cleanReadme": "gulp cleanReadme",
-        "compile": "rimraf dist && webpack --mode none",
-        "watch": "rimraf dist && webpack --mode none --watch",
+        "compile": "tsc -watch",
+        "webpack": "rimraf dist && npm run build && webpack --mode none",
         "lint": "eslint --ext .ts .",
         "lint-fix": "eslint --ext .ts . --fix",
         "package": "vsce package --githubBranch main",


### PR DESCRIPTION
I wanted to make it more explicit that we're always launching the webpacked extension. And I updated the scripts in package.json to more closely resemble our other extensions