### PR TITLE
Switch from `TokenCredentialsBase` to `TokenCredential`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appservice": "^6.0.0",
-                "@azure/arm-resources": "^3.0.0",
-                "@azure/arm-subscriptions": "^2.0.0",
+                "@azure/arm-resources": "^4.2.2",
+                "@azure/arm-subscriptions": "^3.1.2",
                 "@azure/core-auth": "^1.3.2",
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@azure/ms-rest-nodeauth": "^3.0.10",
@@ -91,12 +91,13 @@
             }
         },
         "node_modules/@azure/arm-resources": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
-            "integrity": "sha512-lcddsgwrMJTug8XoKONieGSyPWFZ9ueaUAHdrPfAlS3qyF58txFGVMjb/q5FVd8CKML4EUNDeldL7oLUZmD5Fw==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-4.2.2.tgz",
+            "integrity": "sha512-Oic1OcEwgex3X1KkhP9UM/E/taIaS9oID7PL/CZ8knD7qtVNSRvTxP3uvD3ZpH9NYBYXngJsX5xyRu66iFN+rA==",
             "dependencies": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
+                "@azure/core-auth": "^1.1.4",
+                "@azure/ms-rest-azure-js": "^2.1.0",
+                "@azure/ms-rest-js": "^2.2.0",
                 "tslib": "^1.10.0"
             }
         },
@@ -133,12 +134,13 @@
             }
         },
         "node_modules/@azure/arm-subscriptions": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
-            "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-3.1.2.tgz",
+            "integrity": "sha512-fO1Sxjn27At53Zkgs0tKW9l6iYavfbVgkK4rCFYa2d3M5yofGctHafYDTHQLnp7dYwUzGzTHrBMlyrKo92QpAQ==",
             "dependencies": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
+                "@azure/core-auth": "^1.1.4",
+                "@azure/ms-rest-azure-js": "^2.1.0",
+                "@azure/ms-rest-js": "^2.2.0",
                 "tslib": "^1.10.0"
             }
         },
@@ -10528,6 +10530,17 @@
                 "vscode-sort-package-json": "scripts/sortPackageJson.mjs"
             }
         },
+        "node_modules/vscode-azureextensiondev/node_modules/@azure/arm-subscriptions": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
+            "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
+            "dev": true,
+            "dependencies": {
+                "@azure/ms-rest-azure-js": "^2.0.1",
+                "@azure/ms-rest-js": "^2.0.4",
+                "tslib": "^1.10.0"
+            }
+        },
         "node_modules/vscode-azureextensiondev/node_modules/@types/estree": {
             "version": "0.0.46",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
@@ -10888,6 +10901,26 @@
                 "vscode-extension-telemetry": "^0.1.7",
                 "vscode-nls": "^4.1.1",
                 "vscode-tas-client": "^0.1.22"
+            }
+        },
+        "node_modules/vscode-azureextensionui/node_modules/@azure/arm-resources": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
+            "integrity": "sha512-lcddsgwrMJTug8XoKONieGSyPWFZ9ueaUAHdrPfAlS3qyF58txFGVMjb/q5FVd8CKML4EUNDeldL7oLUZmD5Fw==",
+            "dependencies": {
+                "@azure/ms-rest-azure-js": "^2.0.1",
+                "@azure/ms-rest-js": "^2.0.4",
+                "tslib": "^1.10.0"
+            }
+        },
+        "node_modules/vscode-azureextensionui/node_modules/@azure/arm-subscriptions": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
+            "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
+            "dependencies": {
+                "@azure/ms-rest-azure-js": "^2.0.1",
+                "@azure/ms-rest-js": "^2.0.4",
+                "tslib": "^1.10.0"
             }
         },
         "node_modules/vscode-azureextensionui/node_modules/escape-string-regexp": {
@@ -11606,12 +11639,13 @@
             }
         },
         "@azure/arm-resources": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
-            "integrity": "sha512-lcddsgwrMJTug8XoKONieGSyPWFZ9ueaUAHdrPfAlS3qyF58txFGVMjb/q5FVd8CKML4EUNDeldL7oLUZmD5Fw==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-4.2.2.tgz",
+            "integrity": "sha512-Oic1OcEwgex3X1KkhP9UM/E/taIaS9oID7PL/CZ8knD7qtVNSRvTxP3uvD3ZpH9NYBYXngJsX5xyRu66iFN+rA==",
             "requires": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
+                "@azure/core-auth": "^1.1.4",
+                "@azure/ms-rest-azure-js": "^2.1.0",
+                "@azure/ms-rest-js": "^2.2.0",
                 "tslib": "^1.10.0"
             }
         },
@@ -11648,12 +11682,13 @@
             }
         },
         "@azure/arm-subscriptions": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
-            "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-3.1.2.tgz",
+            "integrity": "sha512-fO1Sxjn27At53Zkgs0tKW9l6iYavfbVgkK4rCFYa2d3M5yofGctHafYDTHQLnp7dYwUzGzTHrBMlyrKo92QpAQ==",
             "requires": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
+                "@azure/core-auth": "^1.1.4",
+                "@azure/ms-rest-azure-js": "^2.1.0",
+                "@azure/ms-rest-js": "^2.2.0",
                 "tslib": "^1.10.0"
             }
         },
@@ -19878,6 +19913,17 @@
                 "webpack": "5.28.0"
             },
             "dependencies": {
+                "@azure/arm-subscriptions": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
+                    "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
+                    "dev": true,
+                    "requires": {
+                        "@azure/ms-rest-azure-js": "^2.0.1",
+                        "@azure/ms-rest-js": "^2.0.4",
+                        "tslib": "^1.10.0"
+                    }
+                },
                 "@types/estree": {
                     "version": "0.0.46",
                     "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
@@ -20169,6 +20215,26 @@
                 "vscode-tas-client": "^0.1.22"
             },
             "dependencies": {
+                "@azure/arm-resources": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-3.0.0.tgz",
+                    "integrity": "sha512-lcddsgwrMJTug8XoKONieGSyPWFZ9ueaUAHdrPfAlS3qyF58txFGVMjb/q5FVd8CKML4EUNDeldL7oLUZmD5Fw==",
+                    "requires": {
+                        "@azure/ms-rest-azure-js": "^2.0.1",
+                        "@azure/ms-rest-js": "^2.0.4",
+                        "tslib": "^1.10.0"
+                    }
+                },
+                "@azure/arm-subscriptions": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-2.0.0.tgz",
+                    "integrity": "sha512-+ys2glK5YgwZ9KhwWblfAQIPABtiB5OdKEpPOpcvr7B5ygYTwZuSUNObX9MRu/MyiRo1zDlUvlxHltBphq/bLQ==",
+                    "requires": {
+                        "@azure/ms-rest-azure-js": "^2.0.1",
+                        "@azure/ms-rest-js": "^2.0.4",
+                        "tslib": "^1.10.0"
+                    }
+                },
                 "escape-string-regexp": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -264,9 +264,8 @@
         "webpack-cli": "^4.5.0"
     },
     "dependencies": {
-        "@azure/arm-appservice": "^6.0.0",
-        "@azure/arm-resources": "^3.0.0",
-        "@azure/arm-subscriptions": "^2.0.0",
+        "@azure/arm-resources": "^4.2.2",
+        "@azure/arm-subscriptions": "^3.1.2",
         "@azure/core-auth": "^1.3.2",
         "@azure/ms-rest-azure-env": "^2.0.0",
         "@azure/ms-rest-nodeauth": "^3.0.10",

--- a/src/azure-account.api.d.ts
+++ b/src/azure-account.api.d.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SubscriptionModels } from '@azure/arm-subscriptions';
+import { TokenCredential } from '@azure/core-auth';
 import { Environment } from '@azure/ms-rest-azure-env';
-import { AzureIdentityCredentialAdapter } from '@azure/ms-rest-js';
 import { TokenCredentialsBase } from '@azure/ms-rest-nodeauth';
 import { ReadStream } from 'fs';
 import { CancellationToken, Event, Progress, Terminal } from 'vscode';
@@ -36,7 +36,7 @@ export interface AzureSession {
 	/**
 	 * The credentials object for azure-sdk-for-js modules https://github.com/azure/azure-sdk-for-js
 	 */
-	readonly credentials2: TokenCredentialsBase | AzureIdentityCredentialAdapter;
+	readonly credentials2: TokenCredentialsBase | TokenCredential;
 }
 
 export interface AzureSubscription {

--- a/src/azure-account.legacy.api.d.ts
+++ b/src/azure-account.legacy.api.d.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { SubscriptionModels } from '@azure/arm-subscriptions';
+import { TokenCredential } from '@azure/core-auth';
 import { Environment } from '@azure/ms-rest-azure-env';
-import { AzureIdentityCredentialAdapter } from '@azure/ms-rest-js';
 import { TokenCredentialsBase } from '@azure/ms-rest-nodeauth';
 import { ReadStream } from 'fs';
 import { ServiceClientCredentials } from 'ms-rest';
@@ -44,7 +44,7 @@ export interface AzureSession {
 	/**
 	 * The credentials object for azure-sdk-for-js modules https://github.com/azure/azure-sdk-for-js
 	 */
-	readonly credentials2: TokenCredentialsBase | AzureIdentityCredentialAdapter;
+	readonly credentials2: TokenCredentialsBase | TokenCredential;
 }
 
 export interface AzureSubscription {

--- a/src/login/AuthProviderBase.ts
+++ b/src/login/AuthProviderBase.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { TokenCredential } from "@azure/core-auth";
 import { Environment } from "@azure/ms-rest-azure-env";
-import { AzureIdentityCredentialAdapter } from '@azure/ms-rest-js';
 import { DeviceTokenCredentials as DeviceTokenCredentials2 } from '@azure/ms-rest-nodeauth';
 import { AccountInfo } from "@azure/msal-node";
 import { randomBytes } from "crypto";
@@ -23,7 +23,7 @@ import { getKey } from "./getKey";
 import { CodeResult, createServer, createTerminateServer, RedirectResult, startServer } from './server';
 
 export type AbstractCredentials = DeviceTokenCredentials;
-export type AbstractCredentials2 = DeviceTokenCredentials2 | AzureIdentityCredentialAdapter;
+export type AbstractCredentials2 = DeviceTokenCredentials2 | TokenCredential;
 
 export abstract class AuthProviderBase<TLoginResult> {
 	private terminateServer: (() => Promise<void>) | undefined;

--- a/src/login/msal/MsalAuthProvider.ts
+++ b/src/login/msal/MsalAuthProvider.ts
@@ -94,7 +94,6 @@ export class MsalAuthProvider extends AuthProviderBase<AuthenticationResult> {
 	public getCredentials2(_env: Environment, _userId: string, _tenantId: string, accountInfo?: AccountInfo): AbstractCredentials2 {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		return new PublicClientCredential(this.publicClientApp, accountInfo!);
-
 	}
 
 	public async updateSessions(environment: Environment, loginResult: AuthenticationResult, sessions: AzureSession[]): Promise<void> {

--- a/src/login/msal/MsalAuthProvider.ts
+++ b/src/login/msal/MsalAuthProvider.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Environment } from "@azure/ms-rest-azure-env";
-import { AzureIdentityCredentialAdapter } from '@azure/ms-rest-js';
 import { DeviceCodeResponse } from "@azure/msal-common";
 import { AccountInfo, AuthenticationResult, Configuration, LogLevel, PublicClientApplication, TokenCache } from "@azure/msal-node";
 import { AzureSession } from "../../azure-account.api";
@@ -93,9 +92,9 @@ export class MsalAuthProvider extends AuthProviderBase<AuthenticationResult> {
 	}
 
 	public getCredentials2(_env: Environment, _userId: string, _tenantId: string, accountInfo?: AccountInfo): AbstractCredentials2 {
-		// The Azure Functions & App Service API endpoints don't accept the default scope (audience) provided by `AzureIdentityCredentialAdapter` so provide the legacy scope
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return new AzureIdentityCredentialAdapter(new PublicClientCredential(this.publicClientApp, accountInfo!), 'https://management.core.windows.net/.default');
+		return new PublicClientCredential(this.publicClientApp, accountInfo!);
+
 	}
 
 	public async updateSessions(environment: Environment, loginResult: AuthenticationResult, sessions: AzureSession[]): Promise<void> {

--- a/src/login/msal/PublicClientCredential.ts
+++ b/src/login/msal/PublicClientCredential.ts
@@ -6,7 +6,7 @@
 import { AccessToken, TokenCredential } from "@azure/core-auth";
 import { AccountInfo, AuthenticationResult, PublicClientApplication } from "@azure/msal-node";
 
-export class PublicClientCredential implements TokenCredential { 
+export class PublicClientCredential implements TokenCredential {
 	private publicClientApp: PublicClientApplication;
 	private accountInfo: AccountInfo;
 
@@ -17,7 +17,12 @@ export class PublicClientCredential implements TokenCredential {
 
 	public async getToken(scopes: string | string[]): Promise<AccessToken | null> {
 		scopes = Array.isArray(scopes) ? scopes : [scopes];
-		
+
+		if (scopes.length === 1 && scopes[0] === 'https://management.azure.com/.default') {
+			// The Azure Functions & App Service APIs only accept the legacy scope
+			scopes = ['https://management.core.windows.net/.default'];
+		}
+
 		const authResult: AuthenticationResult | null = await this.publicClientApp.acquireTokenSilent({
 			scopes,
 			account: this.accountInfo


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/317

As mentioned in the above issue, `TokenCredentialsBase` is part of the deprecated [@azure/ms-rest-nodeauth](https://github.com/Azure/azure-sdk-for-node) package so it makes sense to switch to the latest & greatest `TokenCredential` from [@azure/core-auth](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/core-auth). This change wasn't too intrusive - the biggest things to note are:

1. I needed to update a few dependencies so that the right credential type is accepted.
2. Since `AzureIdentityCredentialAdapter` is no longer required, I moved where we insert the scope required by the Functions & App Service APIs to PublicClientCredential.ts.