### PR TITLE
Update default MSAL scope

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,7 +26,7 @@ export const redirectUrlAAD: string = 'https://vscode-redirect.azurewebsites.net
 export const portADFS: number = 19472;
 export const redirectUrlADFS: string = `http://127.0.0.1:${portADFS}/callback`;
 
-export const msalScopes: string[] = ['user.read'];
+export const defaultMsalScopes: string[] = ['https://management.core.windows.net/.default'];
 
 export const staticEnvironments: Environment[] = [
 	Environment.AzureCloud,

--- a/src/login/msal/MsalAuthProvider.ts
+++ b/src/login/msal/MsalAuthProvider.ts
@@ -7,7 +7,7 @@ import { Environment } from "@azure/ms-rest-azure-env";
 import { DeviceCodeResponse } from "@azure/msal-common";
 import { AccountInfo, AuthenticationResult, Configuration, LogLevel, PublicClientApplication, TokenCache } from "@azure/msal-node";
 import { AzureSession } from "../../azure-account.api";
-import { clientId, msalScopes } from "../../constants";
+import { clientId, defaultMsalScopes } from "../../constants";
 import { AzureLoginError } from "../../errors";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
@@ -39,7 +39,7 @@ export class MsalAuthProvider extends AuthProviderBase<AuthenticationResult> {
 
 	public async loginWithAuthCode(code: string, redirectUrl: string): Promise<AuthenticationResult> {
 		const authResult: AuthenticationResult | null = await this.publicClientApp.acquireTokenByCode({
-			scopes: msalScopes,
+			scopes: defaultMsalScopes,
 			code,
 			redirectUri: redirectUrl,
 		});
@@ -53,7 +53,7 @@ export class MsalAuthProvider extends AuthProviderBase<AuthenticationResult> {
 
 	public async loginWithDeviceCode(): Promise<AuthenticationResult> {
 		const authResult: AuthenticationResult | null = await this.publicClientApp.acquireTokenByDeviceCode({
-			scopes: msalScopes,
+			scopes: defaultMsalScopes,
 			deviceCodeCallback: (response: DeviceCodeResponse) => this.showDeviceCodeMessage(response.message, response.userCode, response.verificationUri)
 		});
 
@@ -71,7 +71,7 @@ export class MsalAuthProvider extends AuthProviderBase<AuthenticationResult> {
 
 		if (accountInfo.length === 1) {
 			authResult = await this.publicClientApp.acquireTokenSilent({
-				scopes: msalScopes,
+				scopes: defaultMsalScopes,
 				account: accountInfo[0]
 			});
 

--- a/src/login/msal/PublicClientCredential.ts
+++ b/src/login/msal/PublicClientCredential.ts
@@ -5,6 +5,7 @@
 
 import { AccessToken, TokenCredential } from "@azure/core-auth";
 import { AccountInfo, AuthenticationResult, PublicClientApplication } from "@azure/msal-node";
+import { defaultMsalScopes } from "../../constants";
 
 export class PublicClientCredential implements TokenCredential {
 	private publicClientApp: PublicClientApplication;
@@ -19,8 +20,8 @@ export class PublicClientCredential implements TokenCredential {
 		scopes = Array.isArray(scopes) ? scopes : [scopes];
 
 		if (scopes.length === 1 && scopes[0] === 'https://management.azure.com/.default') {
-			// The Azure Functions & App Service APIs only accept the legacy scope
-			scopes = ['https://management.core.windows.net/.default'];
+			// The Azure Functions & App Service APIs only accept the legacy scope (which is the default scope we use)
+			scopes = defaultMsalScopes;
 		}
 
 		const authResult: AuthenticationResult | null = await this.publicClientApp.acquireTokenSilent({


### PR DESCRIPTION
The original default scope 'user.read' has always been more of a placeholder than something that's actually needed (it governs read access to Microsoft Graph resources). It started causing problems[^1] when I was implementing MSAL support for Cloud Shell and I figured it's better to remove it sooner rather than later.

[^1]: The Cloud Shell API threw an error related to the audience for any tokens acquired with that 'user.read' scope. And Cloud Shell requires the 'https://management.core.windows.net' audience anyway so this change makes sense.