### PR TITLE
Throw a pretty error when attempting to authenticate Cloud Shell with MSAL

### DIFF
--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -22,6 +22,7 @@ import { ext } from '../extensionVariables';
 import { tokenFromRefreshToken } from '../login/adal/tokens';
 import { localize } from '../utils/localize';
 import { Deferred } from '../utils/promiseUtils';
+import { getAuthLibrary } from '../utils/settingUtils';
 import { AccessTokens, connectTerminal, ConsoleUris, Errors, getUserSettings, provisionConsole, resetConsole, Size, UserSettings } from './cloudConsoleLauncher';
 import { CloudShellInternal } from './CloudShellInternal';
 import { createServer, Queue, readJSON, Server } from './ipc';
@@ -318,6 +319,11 @@ export function createCloudConsole(api: AzureAccountExtensionApi, osName: OSName
 			}
 
 			liveServerQueue = serverQueue;
+
+			if (getAuthLibrary() === 'MSAL') {
+				serverQueue.push({ type: 'log', args: [localize('azure-account.doesNotSupportMsal', 'Cloud Shell does not currently support authenticating with MSAL. Please set the "azure.authenticationLibrary" setting to "ADAL" and try again.')] });
+				return;
+			}
 
 			const loginStatus: AzureLoginStatus = await waitForLoginStatus(api);
 			if (loginStatus !== 'LoggedIn') {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/365

I opted to add a log to the shell instead of throwing a "traditional" error because the TerminalProfile throws additional errors when a profile isn't provided (which is what happens when we throw an error from `createCloudConsole`)