### PR TITLE
Don't wait when sending login telemetry

### DIFF
--- a/src/login/AzureLoginHelper.ts
+++ b/src/login/AzureLoginHelper.ts
@@ -154,13 +154,13 @@ export class AzureLoginHelper {
 					await this.authProvider.login(clientId, environment, isAdfs, tenantId, openUri, redirectTimeout) :
 					await this.authProvider.loginWithDeviceCode(environment, tenantId);
 				await this.updateSessions(this.authProvider, environment, loginResult);
-				await this.sendLoginTelemetry(context, trigger, path, environmentName, 'success', undefined, true);
+				void this.sendLoginTelemetry(context, trigger, path, environmentName, 'success', undefined, true);
 			} catch (err) {
 				if (err instanceof AzureLoginError && err.reason) {
 					console.error(err.reason);
-					await this.sendLoginTelemetry(context, trigger, path, environmentName, 'error', getErrorMessage(err.reason) || getErrorMessage(err));
+					void this.sendLoginTelemetry(context, trigger, path, environmentName, 'error', getErrorMessage(err.reason) || getErrorMessage(err));
 				} else {
-					await this.sendLoginTelemetry(context, trigger, path, environmentName, 'failure', getErrorMessage(err));
+					void this.sendLoginTelemetry(context, trigger, path, environmentName, 'failure', getErrorMessage(err));
 				}
 				throw err;
 			} finally {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/364

In `sendLoginTelemetry`, we await `api.waitForSubscriptions` which won't resolve until this line executes:

https://github.com/microsoft/vscode-azure-account/blob/e3bd4d4d94b773fb9b36dbe9a1361c8d9feca653/src/login/AzureLoginHelper.ts#L169

The problem is: the `api.waitForSubscriptions` Promise would never resolve because `sendLoginTelemetry` is called before `updateLoginStatus`. So not awaiting the calls to `sendLoginTelemetry` fixes the problem.
