### PR TITLE
Add bugs URL to package.json, update homepage URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
     "repository": {
         "url": "https://github.com/microsoft/vscode-azure-account.git"
     },
-    "homepage": "https://github.com/Microsoft/vscode-azure-account/blob/master/README.md",
+    "bugs": {
+        "url": "https://github.com/microsoft/vscode-azure-account/issues"
+    },
+    "homepage": "https://github.com/Microsoft/vscode-azure-account/blob/main/README.md",
     "galleryBanner": {
         "color": "#0072c6",
         "theme": "dark"
     },
-    "enableProposedApi": true,
     "version": "0.9.12-alpha",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "publisher": "ms-vscode",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/372

Adding the bugs URL resolves the problem outlined in https://github.com/microsoft/vscode-azure-account/issues/372#issuecomment-981977278 because the incorrect GitHub issue URL is only created if `bugs` doesn't exist in package.json.

I also removed the `enableProposedApi` property which has been replaced (we aren't using any API proposals at the moment anyway): 

<img width="328" alt="Screen Shot 2021-11-29 at 12 18 19 PM" src="https://user-images.githubusercontent.com/22795803/143937343-2cd27af3-ad08-49d1-9902-97369d075159.png">