### PR TITLE
Add `Azure Account: Report Issue...` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "onCommand:azure-account.loginToCloud",
         "onCommand:azure-account.loginWithDeviceCode",
         "onCommand:azure-account.logout",
+        "onCommand:azure-account.reportIssue",
         "onCommand:azure-account.selectSubscriptions",
         "onCommand:azure-account.uploadFileCloudConsole",
         "onTerminalProfile:azure-account.cloudShellBash",
@@ -65,6 +66,11 @@
                 "command": "azure-account.logout",
                 "title": "%azure-account.commands.logout%",
                 "category": "%azure-account.commands.azure%"
+            },
+            {
+                "command": "azure-account.reportIssue",
+                "title": "%azure-account.commands.reportIssue%",
+                "category": "%azure-account.commands.azure-account%"
             },
             {
                 "command": "azure-account.selectSubscriptions",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
             {
                 "command": "azure-account.reportIssue",
                 "title": "%azure-account.commands.reportIssue%",
-                "category": "%azure-account.commands.azure-account%"
+                "category": "%azure-account.commands.azureAccount%"
             },
             {
                 "command": "azure-account.selectSubscriptions",

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,7 +2,7 @@
     "azure-account.cloudShellBash": "Azure Cloud Shell (Bash)",
     "azure-account.cloudShellPowerShell": "Azure Cloud Shell (PowerShell)",
     "azure-account.commands.azure": "Azure",
-    "azure-account.commands.azure-account": "Azure Account",
+    "azure-account.commands.azureAccount": "Azure Account",
     "azure-account.commands.createAccount": "Create an Account",
     "azure-account.commands.login": "Sign In",
     "azure-account.commands.loginToCloud": "Sign In to Azure Cloud",

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,11 +2,13 @@
     "azure-account.cloudShellBash": "Azure Cloud Shell (Bash)",
     "azure-account.cloudShellPowerShell": "Azure Cloud Shell (PowerShell)",
     "azure-account.commands.azure": "Azure",
+    "azure-account.commands.azure-account": "Azure Account",
     "azure-account.commands.createAccount": "Create an Account",
     "azure-account.commands.login": "Sign In",
     "azure-account.commands.loginToCloud": "Sign In to Azure Cloud",
     "azure-account.commands.loginWithDeviceCode": "Sign In with Device Code",
     "azure-account.commands.logout": "Sign Out",
+    "azure-account.commands.reportIssue": "Report Issue...",
     "azure-account.commands.selectSubscriptions": "Select Subscriptions",
     "azure-account.commands.uploadFileCloudConsole": "Upload to Cloud Shell"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@
 import { createReadStream } from 'fs';
 import { basename } from 'path';
 import { CancellationToken, commands, ConfigurationTarget, env, ExtensionContext, ProgressLocation, Uri, window, workspace, WorkspaceConfiguration } from 'vscode';
-import { callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, createExperimentationService, IActionContext, registerUIExtensionVariables } from 'vscode-azureextensionui';
+import { callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, createExperimentationService, IActionContext, registerReportIssueCommand, registerUIExtensionVariables } from 'vscode-azureextensionui';
 import { AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { AzureAccountExtensionApi } from './azure-account.api';
 import { createCloudConsole, OSes, OSName, shells } from './cloudConsole/cloudConsole';
@@ -41,6 +41,7 @@ export async function activateInternal(context: ExtensionContext, perfStats: { l
 		context.subscriptions.push(createStatusBarItem(context, azureLoginHelper.api));
 		context.subscriptions.push(commands.registerCommand('azure-account.createAccount', createAccount));
 		context.subscriptions.push(commands.registerCommand('azure-account.uploadFileCloudConsole', uri => uploadFile(azureLoginHelper.api, uri)));
+		registerReportIssueCommand('azure-account.reportIssue');
 
 		window.registerTerminalProfileProvider('azure-account.cloudShellBash', {
 			provideTerminalProfile: (token: CancellationToken) => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/371

I added this command under the category "Azure Account" instead of "Azure" which is what we normally do for this extension. The `Azure: Report Issue...` command already exists and it would look gross if we added another command with the same name:

<img width="607" alt="Screen Shot 2021-11-29 at 12 46 00 PM" src="https://user-images.githubusercontent.com/22795803/143941305-5b5e2416-05c7-4dec-8e0c-4aeaf9943118.png">