### PR TITLE
Set authentication library based on user setting and exp framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
                         "Azure Active Directory Authentication Library",
                         "Microsoft Authentication Library (Preview)"
                     ],
-                    "description": "The authentication library to use. Note: You must sign out and reload the window after modifying this setting for it to take effect."
+                    "description": "The authentication library to use. The extension will choose a library for you if this setting is left blank. Note: You must sign out and reload the window after modifying this setting for it to take effect."
                 }
             }
         }

--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -20,9 +20,9 @@ import { AzureAccountExtensionApi, AzureLoginStatus, AzureSession, CloudShell, C
 import { AzureSession as AzureSessionLegacy } from '../azure-account.legacy.api';
 import { ext } from '../extensionVariables';
 import { tokenFromRefreshToken } from '../login/adal/tokens';
+import { getAuthLibrary } from '../login/getAuthLibrary';
 import { localize } from '../utils/localize';
 import { Deferred } from '../utils/promiseUtils';
-import { getAuthLibrary } from '../utils/settingUtils';
 import { AccessTokens, connectTerminal, ConsoleUris, Errors, getUserSettings, provisionConsole, resetConsole, Size, UserSettings } from './cloudConsoleLauncher';
 import { CloudShellInternal } from './CloudShellInternal';
 import { createServer, Queue, readJSON, Server } from './ipc';

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -14,4 +14,5 @@ export namespace ext {
     export let outputChannel: IAzExtOutputChannel;
     export let uriEventHandler: UriEventHandler;
     export let experimentationService: IExperimentationServiceAdapter;
+    export let isMsalTreatmentVariable: boolean | undefined;
 }

--- a/src/login/AzureLoginHelper.ts
+++ b/src/login/AzureLoginHelper.ts
@@ -11,7 +11,7 @@ import { authLibrarySetting, cacheKey, clientId, cloudSetting, commonTenantId, c
 import { AzureLoginError, getErrorMessage } from '../errors';
 import { localize } from '../utils/localize';
 import { openUri } from '../utils/openUri';
-import { getAuthLibrary, getSettingValue, getSettingWithPrefix } from '../utils/settingUtils';
+import { getSettingValue, getSettingWithPrefix } from '../utils/settingUtils';
 import { delay } from '../utils/timeUtils';
 import { AdalAuthProvider } from './adal/AdalAuthProvider';
 import { AuthProviderBase } from './AuthProviderBase';
@@ -19,6 +19,7 @@ import { AzureAccountExtensionApi } from './AzureAccountExtensionApi';
 import { AzureAccountExtensionLegacyApi } from './AzureAccountExtensionLegacyApi';
 import { getSelectedEnvironment, isADFS } from './environments';
 import { getNewFilters } from './filters';
+import { getAuthLibrary } from './getAuthLibrary';
 import { getKey } from './getKey';
 import { MsalAuthProvider } from './msal/MsalAuthProvider';
 import { checkRedirectServer } from './server';

--- a/src/login/getAuthLibrary.ts
+++ b/src/login/getAuthLibrary.ts
@@ -9,8 +9,7 @@ import { ext } from "../extensionVariables";
 import { getSettingValue } from "../utils/settingUtils";
 
 export function getAuthLibrary(): AuthLibrary {
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	return (callWithTelemetryAndErrorHandlingSync('getAuthLibrary', (context: IActionContext) => {
+	return callWithTelemetryAndErrorHandlingSync('getAuthLibrary', (context: IActionContext) => {
 		let authLibrary: AuthLibrary | undefined = getSettingValue<AuthLibrary>(authLibrarySetting);
 
 		switch (authLibrary) {
@@ -30,5 +29,5 @@ export function getAuthLibrary(): AuthLibrary {
 		}
 
 		return authLibrary;
-	}))!;
+	}) as AuthLibrary;
 }

--- a/src/login/getAuthLibrary.ts
+++ b/src/login/getAuthLibrary.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { callWithTelemetryAndErrorHandlingSync, IActionContext } from "vscode-azureextensionui";
+import { AuthLibrary, authLibrarySetting } from "../constants";
+import { ext } from "../extensionVariables";
+import { getSettingValue } from "../utils/settingUtils";
+
+export function getAuthLibrary(): AuthLibrary {
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+	return (callWithTelemetryAndErrorHandlingSync('getAuthLibrary', (context: IActionContext) => {
+		let authLibrary: AuthLibrary | undefined = getSettingValue<AuthLibrary>(authLibrarySetting);
+
+		switch (authLibrary) {
+			case 'MSAL':
+				context.telemetry.properties.authLibrarySetting = 'MSAL';
+				break;
+			case 'ADAL':
+				context.telemetry.properties.authLibrarySetting = 'ADAL';
+				break;
+			default:
+				context.telemetry.properties.authLibrarySetting = 'undefined';
+				if (ext.isMsalTreatmentVariable) {
+					authLibrary = 'MSAL';
+				} else {
+					authLibrary = 'ADAL';
+				}
+		}
+
+		return authLibrary;
+	}))!;
+}

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { workspace, WorkspaceConfiguration } from "vscode";
-import { AuthLibrary, authLibrarySetting, extensionPrefix } from "../constants";
+import { extensionPrefix } from "../constants";
 
 export function getSettingWithPrefix(settingName: string): string {
 	return `${extensionPrefix}.${settingName}`;
@@ -13,8 +13,4 @@ export function getSettingWithPrefix(settingName: string): string {
 export function getSettingValue<T>(settingName: string): T | undefined {
 	const config: WorkspaceConfiguration = workspace.getConfiguration(extensionPrefix);
 	return config.get(settingName);
-}
-
-export function getAuthLibrary(): AuthLibrary {
-	return getSettingValue<AuthLibrary>(authLibrarySetting) || 'ADAL';
 }


### PR DESCRIPTION
The user's `azure.authLibrary` setting takes precedence over the auth library the experimentation framework tells us to use. Also I added telemetry for the auth library setting so we can filter out users from the A/B test reports who manually set their auth library (I believe that's all that is required in the extension to do that filtering)