### PR TITLE
Add 'Select Tenant' command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true,
         "source.organizeImports": true
-    }
+    },
+    "azure.tenant": "72f988bf-86f1-41af-91ab-2d7cd011db47"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,5 @@
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true,
         "source.organizeImports": true
-    },
-    "azure.tenant": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "onCommand:azure-account.logout",
         "onCommand:azure-account.reportIssue",
         "onCommand:azure-account.selectSubscriptions",
+        "onCommand:azure-account.selectTenant",
         "onCommand:azure-account.uploadFileCloudConsole",
         "onTerminalProfile:azure-account.cloudShellBash",
         "onTerminalProfile:azure-account.cloudShellPowerShell"
@@ -75,6 +76,11 @@
             {
                 "command": "azure-account.selectSubscriptions",
                 "title": "%azure-account.commands.selectSubscriptions%",
+                "category": "%azure-account.commands.azure%"
+            },
+            {
+                "command": "azure-account.selectTenant",
+                "title": "%azure-account.commands.selectTenant%",
                 "category": "%azure-account.commands.azure%"
             },
             {

--- a/package.nls.json
+++ b/package.nls.json
@@ -10,5 +10,6 @@
     "azure-account.commands.logout": "Sign Out",
     "azure-account.commands.reportIssue": "Report Issue...",
     "azure-account.commands.selectSubscriptions": "Select Subscriptions",
+    "azure-account.commands.selectTenant": "Select Tenant",
     "azure-account.commands.uploadFileCloudConsole": "Upload to Cloud Shell"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { AzureAccountLoginHelper } from './login/AzureLoginHelper';
 import { askForLogin } from './login/commands/askForLogin';
 import { loginToCloud } from './login/commands/loginToCloud';
 import { selectSubscriptions } from './login/commands/selectSubscriptions';
+import { selectTenant } from './login/commands/selectTenant';
 import { UriEventHandler } from './login/exchangeCodeForToken';
 import { updateFilters } from './login/updateFilters';
 import { updateSubscriptions } from './login/updateSubscriptions';
@@ -49,6 +50,7 @@ export async function activateInternal(context: ExtensionContext, perfStats: { l
 		context.subscriptions.push(createStatusBarItem(context, ext.loginHelper.api));
 		context.subscriptions.push(commands.registerCommand('azure-account.loginToCloud', loginToCloud));
 		context.subscriptions.push(commands.registerCommand('azure-account.selectSubscriptions', selectSubscriptions));
+		context.subscriptions.push(commands.registerCommand('azure-account.selectTenant', selectTenant));
 		context.subscriptions.push(commands.registerCommand('azure-account.askForLogin', askForLogin));
 		context.subscriptions.push(commands.registerCommand('azure-account.createAccount', createAccount));
 		context.subscriptions.push(commands.registerCommand('azure-account.uploadFileCloudConsole', uri => uploadFile(ext.loginHelper.api, uri)));

--- a/src/login/commands/selectTenant.ts
+++ b/src/login/commands/selectTenant.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { commands, window } from "vscode";
+import { callWithTelemetryAndErrorHandling, IActionContext } from "vscode-azureextensionui";
+import { tenantSetting } from "../../constants";
+import { ext } from "../../extensionVariables";
+import { localize } from "../../utils/localize";
+import { openUri } from "../../utils/openUri";
+import { updateSettingValue } from "../../utils/settingUtils";
+import { AzureResourceFilterInternal } from "../subscriptionTypes";
+
+export async function selectTenant(): Promise<void> {
+	await callWithTelemetryAndErrorHandling('azure-account.selectTenant', async (context: IActionContext) => {
+		if (!(await ext.loginHelper.api.waitForFilters())) {
+			context.telemetry.properties.outcome = 'notLoggedIn';
+			return commands.executeCommand('azure-account.askForLogin');
+		}
+
+		const tenantSet = new Set<string>();
+		for (const filter of ext.loginHelper.api.filters) {
+			for (const tenant of (<AzureResourceFilterInternal>filter).tenants) {
+				tenantSet.add(tenant);
+			}
+		}
+		const tenants: string[] = Array.from(tenantSet);
+
+		if (!tenants.length) {
+			context.telemetry.properties.outcome = 'noTenantsFound';
+			const noTenantsFound = localize('azure-account.noTenantsFound', 'No tenants were found for the subscription(s) you\'ve selected.');
+			const learnMoreAboutTenants = { title: localize('azure-account.learnMoreAboutTenants', 'Learn more about tenants') };
+			void context.ui.showWarningMessage(noTenantsFound, learnMoreAboutTenants).then(result => {
+				if (result === learnMoreAboutTenants) {
+					void openUri('https://aka.ms/AAfe10l');
+				}
+			});
+		}
+
+		const enterCustomTenant = { label: localize('azure-account.enterCustomTenantWithPencil', '$(pencil) Enter custom tenant') };
+		const picks = [...tenants.map(tenant => { return { label: tenant } }), enterCustomTenant];
+		const placeHolder = localize('azure-account.selectTenantPlaceHolder', 'Select a tenant. This will update the "azure.tenant" workspace setting.');
+		const result = await context.ui.showQuickPick(picks, { placeHolder });
+		if (result) {
+			let tenant: string;
+
+			if (result === enterCustomTenant) {
+				context.telemetry.properties.enterCustomTenant = 'true';
+				tenant = await context.ui.showInputBox({ prompt: localize('enterCustomTenant', 'Enter custom tenant') });
+			} else {
+				tenant = result.label;
+			}
+
+			context.telemetry.properties.outcome = 'tenantSelected';
+			await updateSettingValue(tenantSetting, tenant);
+
+			const mustSignOut: string = localize('azure-account.mustSignOut', 'You must sign out and sign back in for tenant "{0}" to take effect.', tenant);
+			const signOut: string = localize('azure-account.signOut', 'Sign Out');
+			void window.showInformationMessage(mustSignOut, signOut).then(async value => {
+				if (value === signOut) {
+					await ext.loginHelper.logout();
+				}
+			});
+		}
+	});
+}

--- a/src/login/filters.ts
+++ b/src/login/filters.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureResourceFilter, AzureSubscription } from "../azure-account.api";
-import { ISubscriptionItem } from "./subscriptionTypes";
+import { AzureResourceFilterInternal, AzureSubscriptionInternal, ISubscriptionItem } from "./subscriptionTypes";
 
 export function addFilter(resourceFilter: string[], item: ISubscriptionItem): void {
 	const { session, subscription } = item.subscription;
@@ -19,7 +18,7 @@ export function removeFilter(resourceFilter: string[], item: ISubscriptionItem):
 	item.picked = false;
 }
 
-export function getNewFilters(subscriptions: AzureSubscription[], resourceFilter: string[] | undefined): AzureResourceFilter[] {
+export function getNewFilters(subscriptions: AzureSubscriptionInternal[], resourceFilter: string[] | undefined): AzureResourceFilterInternal[] {
 	if (resourceFilter && !Array.isArray(resourceFilter)) {
 		resourceFilter = [];
 	}

--- a/src/login/subscriptionTypes.ts
+++ b/src/login/subscriptionTypes.ts
@@ -21,5 +21,12 @@ export interface ISubscriptionCache {
 			accountInfo?: AccountInfo;
 		};
 		subscription: SubscriptionModels.Subscription;
+		tenants: string[];
 	}[];
 }
+
+export interface AzureSubscriptionInternal extends AzureSubscription {
+	tenants: string[];
+}
+
+export type AzureResourceFilterInternal = AzureSubscriptionInternal;

--- a/src/login/updateFilters.ts
+++ b/src/login/updateFilters.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureSubscription } from "../azure-account.api";
 import { resourceFilterSetting } from "../constants";
 import { ext } from "../extensionVariables";
 import { getSettingValue } from "../utils/settingUtils";
 import { getNewFilters } from "./filters";
+import { AzureResourceFilterInternal, AzureSubscriptionInternal } from "./subscriptionTypes";
 
 export function updateFilters(configChange = false): void {
 	const resourceFilter: string[] | undefined = getSettingValue(resourceFilterSetting);
@@ -16,11 +16,11 @@ export function updateFilters(configChange = false): void {
 	}
 	ext.loginHelper.filtersTask = (async () => {
 		await ext.loginHelper.api.waitForSubscriptions();
-		const subscriptions: AzureSubscription[] = await ext.loginHelper.subscriptionsTask;
+		const subscriptions: AzureSubscriptionInternal[] = await ext.loginHelper.subscriptionsTask;
 		ext.loginHelper.oldResourceFilter = JSON.stringify(resourceFilter);
-		const newFilters: AzureSubscription[] = getNewFilters(subscriptions, resourceFilter);
+		const newFilters: AzureResourceFilterInternal[] = getNewFilters(subscriptions, resourceFilter);
 		ext.loginHelper.api.filters.splice(0, ext.loginHelper.api.filters.length, ...newFilters);
 		ext.loginHelper.onFiltersChanged.fire();
-		return ext.loginHelper.api.filters;
+		return <AzureResourceFilterInternal[]>ext.loginHelper.api.filters;
 	})();
 }

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -14,3 +14,8 @@ export function getSettingValue<T>(settingName: string): T | undefined {
 	const config: WorkspaceConfiguration = workspace.getConfiguration(extensionPrefix);
 	return config.get(settingName);
 }
+
+export async function updateSettingValue<T>(settingName: string, value: T): Promise<void> {
+	const config: WorkspaceConfiguration = workspace.getConfiguration(extensionPrefix);
+	await config.update(settingName, value);
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/101

I also updated the [troubleshooting wiki page](https://github.com/microsoft/vscode-azure-account/wiki/Troubleshooting) to recommend this command first when troubleshooting tenant problems.

One potential issue here is if a user enters a custom tenant that is wrong then attempts to sign in, they won't be able to use the "Select Tenant" command to update the tenant. This is because we require the user to be signed in when this command is run to dynamically get a list of available tenants.