### PR TITLE
Rework 'Select Tenant' command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import { selectSubscriptions } from './login/commands/selectSubscriptions';
 import { selectTenant } from './login/commands/selectTenant';
 import { UriEventHandler } from './login/exchangeCodeForToken';
 import { updateFilters } from './login/updateFilters';
-import { updateSubscriptions } from './login/updateSubscriptions';
+import { updateSubscriptionsAndTenants } from './login/updateSubscriptions';
 import { survey } from './nps';
 import { localize } from './utils/localize';
 import { logErrorMessage } from './utils/logErrorMessage';
@@ -54,7 +54,7 @@ export async function activateInternal(context: ExtensionContext, perfStats: { l
 		context.subscriptions.push(commands.registerCommand('azure-account.askForLogin', askForLogin));
 		context.subscriptions.push(commands.registerCommand('azure-account.createAccount', createAccount));
 		context.subscriptions.push(commands.registerCommand('azure-account.uploadFileCloudConsole', uri => uploadFile(ext.loginHelper.api, uri)));
-		context.subscriptions.push(ext.loginHelper.api.onSessionsChanged(updateSubscriptions));
+		context.subscriptions.push(ext.loginHelper.api.onSessionsChanged(updateSubscriptionsAndTenants));
 		context.subscriptions.push(ext.loginHelper.api.onSubscriptionsChanged(() => updateFilters()));
 		registerReportIssueCommand('azure-account.reportIssue');
 

--- a/src/login/AuthProviderBase.ts
+++ b/src/login/AuthProviderBase.ts
@@ -22,7 +22,7 @@ import { getEnvironments } from "./environments";
 import { exchangeCodeForToken } from "./exchangeCodeForToken";
 import { getKey } from "./getKey";
 import { CodeResult, createServer, createTerminateServer, RedirectResult, startServer } from './server';
-import { ISubscriptionCache } from "./subscriptionTypes";
+import { SubscriptionTenantCache } from "./subscriptionTypes";
 
 export type AbstractCredentials = DeviceTokenCredentials;
 export type AbstractCredentials2 = DeviceTokenCredentials2 | TokenCredential;
@@ -130,7 +130,7 @@ export abstract class AuthProviderBase<TLoginResult> {
 		return await Promise.race([exchangeCodeForToken<TLoginResult>(this, clientId, environment, tenantId, redirectUrlAAD, state), timeoutPromise]);
 	}
 
-	public async initializeSessions(cache: ISubscriptionCache, api: AzureAccountExtensionApi): Promise<Record<string, AzureSession>> {
+	public async initializeSessions(cache: SubscriptionTenantCache, api: AzureAccountExtensionApi): Promise<Record<string, AzureSession>> {
 		const sessions: Record<string, AzureSessionInternal> = {};
 		const environments: Environment[] = await getEnvironments();
 

--- a/src/login/commands/selectTenant.ts
+++ b/src/login/commands/selectTenant.ts
@@ -3,43 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { commands, window } from "vscode";
+import { window } from "vscode";
 import { callWithTelemetryAndErrorHandling, IActionContext } from "vscode-azureextensionui";
 import { tenantSetting } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
-import { openUri } from "../../utils/openUri";
 import { updateSettingValue } from "../../utils/settingUtils";
-import { AzureResourceFilterInternal } from "../subscriptionTypes";
 
 export async function selectTenant(): Promise<void> {
 	await callWithTelemetryAndErrorHandling('azure-account.selectTenant', async (context: IActionContext) => {
-		if (!(await ext.loginHelper.api.waitForFilters())) {
-			context.telemetry.properties.outcome = 'notLoggedIn';
-			return commands.executeCommand('azure-account.askForLogin');
-		}
-
-		const tenantSet = new Set<string>();
-		for (const filter of ext.loginHelper.api.filters) {
-			for (const tenant of (<AzureResourceFilterInternal>filter).tenants) {
-				tenantSet.add(tenant);
-			}
-		}
-		const tenants: string[] = Array.from(tenantSet);
-
-		if (!tenants.length) {
-			context.telemetry.properties.outcome = 'noTenantsFound';
-			const noTenantsFound = localize('azure-account.noTenantsFound', 'No tenants were found for the subscription(s) you\'ve selected.');
-			const learnMoreAboutTenants = { title: localize('azure-account.learnMoreAboutTenants', 'Learn more about tenants') };
-			void context.ui.showWarningMessage(noTenantsFound, learnMoreAboutTenants).then(result => {
-				if (result === learnMoreAboutTenants) {
-					void openUri('https://aka.ms/AAfe10l');
-				}
-			});
-		}
-
+		const tenants: string[] = await ext.loginHelper.tenantsTask;
 		const enterCustomTenant = { label: localize('azure-account.enterCustomTenantWithPencil', '$(pencil) Enter custom tenant') };
-		const picks = [...tenants.map(tenant => { return { label: tenant } }), enterCustomTenant];
+		const picks = [
+			...tenants.map(tenant => { return { label: tenant } }),
+			enterCustomTenant
+		];
 		const placeHolder = localize('azure-account.selectTenantPlaceHolder', 'Select a tenant. This will update the "azure.tenant" workspace setting.');
 		const result = await context.ui.showQuickPick(picks, { placeHolder });
 		if (result) {
@@ -55,13 +33,15 @@ export async function selectTenant(): Promise<void> {
 			context.telemetry.properties.outcome = 'tenantSelected';
 			await updateSettingValue(tenantSetting, tenant);
 
-			const mustSignOut: string = localize('azure-account.mustSignOut', 'You must sign out and sign back in for tenant "{0}" to take effect.', tenant);
-			const signOut: string = localize('azure-account.signOut', 'Sign Out');
-			void window.showInformationMessage(mustSignOut, signOut).then(async value => {
-				if (value === signOut) {
-					await ext.loginHelper.logout();
-				}
-			});
+			if (ext.loginHelper.api.status === 'LoggedIn') {
+				const mustSignOut: string = localize('azure-account.mustSignOut', 'You must sign out and sign back in for tenant "{0}" to take effect.', tenant);
+				const signOut: string = localize('azure-account.signOut', 'Sign Out');
+				void window.showInformationMessage(mustSignOut, signOut).then(async value => {
+					if (value === signOut) {
+						await ext.loginHelper.logout();
+					}
+				});
+			}
 		}
 	});
 }

--- a/src/login/filters.ts
+++ b/src/login/filters.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureResourceFilterInternal, AzureSubscriptionInternal, ISubscriptionItem } from "./subscriptionTypes";
+import { AzureResourceFilter, AzureSubscription } from "../azure-account.api";
+import { ISubscriptionItem } from "./subscriptionTypes";
 
 export function addFilter(resourceFilter: string[], item: ISubscriptionItem): void {
 	const { session, subscription } = item.subscription;
@@ -18,7 +19,7 @@ export function removeFilter(resourceFilter: string[], item: ISubscriptionItem):
 	item.picked = false;
 }
 
-export function getNewFilters(subscriptions: AzureSubscriptionInternal[], resourceFilter: string[] | undefined): AzureResourceFilterInternal[] {
+export function getNewFilters(subscriptions: AzureSubscription[], resourceFilter: string[] | undefined): AzureResourceFilter[] {
 	if (resourceFilter && !Array.isArray(resourceFilter)) {
 		resourceFilter = [];
 	}

--- a/src/login/subscriptionTypes.ts
+++ b/src/login/subscriptionTypes.ts
@@ -12,7 +12,7 @@ export interface ISubscriptionItem extends QuickPickItem {
 	subscription: AzureSubscription;
 }
 
-export interface ISubscriptionCache {
+export interface SubscriptionTenantCache {
 	subscriptions: {
 		session: {
 			environment: string;
@@ -21,12 +21,6 @@ export interface ISubscriptionCache {
 			accountInfo?: AccountInfo;
 		};
 		subscription: SubscriptionModels.Subscription;
-		tenants: string[];
 	}[];
-}
-
-export interface AzureSubscriptionInternal extends AzureSubscription {
 	tenants: string[];
 }
-
-export type AzureResourceFilterInternal = AzureSubscriptionInternal;

--- a/src/login/updateFilters.ts
+++ b/src/login/updateFilters.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzureSubscription } from "../azure-account.api";
 import { resourceFilterSetting } from "../constants";
 import { ext } from "../extensionVariables";
 import { getSettingValue } from "../utils/settingUtils";
 import { getNewFilters } from "./filters";
-import { AzureResourceFilterInternal, AzureSubscriptionInternal } from "./subscriptionTypes";
 
 export function updateFilters(configChange = false): void {
 	const resourceFilter: string[] | undefined = getSettingValue(resourceFilterSetting);
@@ -16,11 +16,11 @@ export function updateFilters(configChange = false): void {
 	}
 	ext.loginHelper.filtersTask = (async () => {
 		await ext.loginHelper.api.waitForSubscriptions();
-		const subscriptions: AzureSubscriptionInternal[] = await ext.loginHelper.subscriptionsTask;
+		const subscriptions: AzureSubscription[] = await ext.loginHelper.subscriptionsTask;
 		ext.loginHelper.oldResourceFilter = JSON.stringify(resourceFilter);
-		const newFilters: AzureResourceFilterInternal[] = getNewFilters(subscriptions, resourceFilter);
+		const newFilters: AzureSubscription[] = getNewFilters(subscriptions, resourceFilter);
 		ext.loginHelper.api.filters.splice(0, ext.loginHelper.api.filters.length, ...newFilters);
 		ext.loginHelper.onFiltersChanged.fire();
-		return <AzureResourceFilterInternal[]>ext.loginHelper.api.filters;
+		return ext.loginHelper.api.filters;
 	})();
 }


### PR DESCRIPTION
I didn't properly understand the relationship between tenants & subscriptions when I first introduced the "Select Tenant" command in https://github.com/microsoft/vscode-azure-account/pull/395 so I've fixed it here. Shoutout to @nturinski and @alexweininger for helping me get a better handle on how these things are related.

A few things to note about this change:

* We can only list subscriptions associated with the tenant the user signed in with. We have access to list all tenants available to a particular user though. So in the cache, the list of all available tenants is now stored at the same level in the object as the subscriptions list.
* We no longer require the user to be signed in to run the "Select Tenant" command. This requirement originally created a "chicken & the egg" problem. Now if they aren't signed in, only the "Enter custom tenant" option is shown (no auto-fetched tenants). This means that the "No tenants found" notification needed to be removed since that's a mainline scenario now.