### PR TITLE
Show tenant `displayName` in tenants quick pick

### DIFF
--- a/src/login/AzureLoginHelper.ts
+++ b/src/login/AzureLoginHelper.ts
@@ -26,6 +26,7 @@ import { getKey } from './getKey';
 import { MsalAuthProvider } from './msal/MsalAuthProvider';
 import { checkRedirectServer } from './server';
 import { SubscriptionTenantCache } from './subscriptionTypes';
+import { TenantIdDescription } from './TenantIdDescription';
 import { updateFilters } from './updateFilters';
 import { waitUntilOnline } from './waitUntilOnline';
 
@@ -52,7 +53,7 @@ export class AzureAccountLoginHelper {
 
 	public filtersTask: Promise<AzureResourceFilter[]> = Promise.resolve(<AzureResourceFilter[]>[]);
 	public subscriptionsTask: Promise<AzureSubscription[]> = Promise.resolve(<AzureSubscription[]>[]);
-	public tenantsTask: Promise<string[]> = Promise.resolve(<string[]>[]);
+	public tenantsTask: Promise<TenantIdDescription[]> = Promise.resolve(<TenantIdDescription[]>[]);
 
 	public api: AzureAccountExtensionApi;
 	public legacyApi: AzureAccountExtensionLegacyApi;

--- a/src/login/TenantIdDescription.ts
+++ b/src/login/TenantIdDescription.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Source: https://docs.microsoft.com/en-us/rest/api/resources/Tenants/List#tenantiddescription
+export interface TenantIdDescription {
+	tenantId: string;
+	displayName: string;
+}

--- a/src/login/commands/selectTenant.ts
+++ b/src/login/commands/selectTenant.ts
@@ -9,13 +9,19 @@ import { tenantSetting } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
 import { updateSettingValue } from "../../utils/settingUtils";
+import { TenantIdDescription } from "../TenantIdDescription";
 
 export async function selectTenant(): Promise<void> {
 	await callWithTelemetryAndErrorHandling('azure-account.selectTenant', async (context: IActionContext) => {
-		const tenants: string[] = await ext.loginHelper.tenantsTask;
+		const tenants: TenantIdDescription[] = await ext.loginHelper.tenantsTask;
 		const enterCustomTenant = { label: localize('azure-account.enterCustomTenantWithPencil', '$(pencil) Enter custom tenant') };
 		const picks = [
-			...tenants.map(tenant => { return { label: tenant } }),
+			...tenants.map(tenant => {
+				return {
+					label: tenant.tenantId,
+					description: tenant.displayName
+				}
+			}),
 			enterCustomTenant
 		];
 		const placeHolder = localize('azure-account.selectTenantPlaceHolder', 'Select a tenant. This will update the "azure.tenant" workspace setting.');

--- a/src/login/subscriptionTypes.ts
+++ b/src/login/subscriptionTypes.ts
@@ -7,6 +7,7 @@ import { SubscriptionModels } from "@azure/arm-subscriptions";
 import { AccountInfo } from "@azure/msal-node";
 import { QuickPickItem } from "vscode";
 import { AzureSubscription } from "../azure-account.api";
+import { TenantIdDescription } from "./TenantIdDescription";
 
 export interface ISubscriptionItem extends QuickPickItem {
 	subscription: AzureSubscription;
@@ -22,5 +23,5 @@ export interface SubscriptionTenantCache {
 		};
 		subscription: SubscriptionModels.Subscription;
 	}[];
-	tenants: string[];
+	tenants: TenantIdDescription[];
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/398

Here's how the new "Select Tenant" command looks. The display name for each tenant is now the "description" for the quick pick items.
![image](https://user-images.githubusercontent.com/22795803/149045706-edbeeb70-9f36-4a26-a199-2704b1fe1e47.png)
