### PR TITLE
Only add `ms-enable-electron-run-as-node` flag to cloud shell process for Mac platform

### DIFF
--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import * as semver from 'semver';
 import { parse, UrlWithStringQuery } from 'url';
 import { v4 as uuid } from 'uuid';
-import { CancellationToken, commands, Disposable, env, EventEmitter, MessageItem, QuickPickItem, Terminal, TerminalOptions, TerminalProfile, ThemeIcon, UIKind, Uri, version, window } from 'vscode';
+import { CancellationToken, commands, Disposable, env, EventEmitter, MessageItem, QuickPickItem, Terminal, TerminalOptions, TerminalProfile, ThemeIcon, Uri, version, window } from 'vscode';
 import { callWithTelemetryAndErrorHandlingSync, IActionContext, IParsedError, parseError } from 'vscode-azureextensionui';
 import { AzureAccountExtensionApi, AzureLoginStatus, AzureSession, CloudShell, CloudShellStatus, UploadOptions } from '../azure-account.api';
 import { AzureSession as AzureSessionLegacy } from '../azure-account.legacy.api';
@@ -208,7 +208,6 @@ export function createCloudConsole(api: AzureAccountExtensionApi, osName: OSName
 			void commands.executeCommand('setContext', 'openCloudConsoleCount', `${shells.length}`);
 
 			const isWindows: boolean = process.platform === 'win32';
-			const isWeb: boolean = env.uiKind === UIKind.Web;
 			if (isWindows) {
 				// See below
 				try {
@@ -274,7 +273,7 @@ export function createCloudConsole(api: AzureAccountExtensionApi, osName: OSName
 				shellArgs.shift();
 			}
 
-			if (!isWindows && !isWeb && semver.gte(version, '1.62.1')) {
+			if (process.platform === 'darwin' && semver.gte(version, '1.62.1')) {
 				// https://github.com/microsoft/vscode/issues/136987
 				// This fix can't be applied to all versions of VS Code. An error is thrown in versions less than the one specified
 				shellArgs.push('--ms-enable-electron-run-as-node');

--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import * as semver from 'semver';
 import { parse, UrlWithStringQuery } from 'url';
 import { v4 as uuid } from 'uuid';
-import { CancellationToken, commands, Disposable, env, EventEmitter, MessageItem, QuickPickItem, Terminal, TerminalOptions, TerminalProfile, ThemeIcon, Uri, version, window } from 'vscode';
+import { CancellationToken, commands, Disposable, env, EventEmitter, MessageItem, QuickPickItem, Terminal, TerminalOptions, TerminalProfile, ThemeIcon, UIKind, Uri, version, window } from 'vscode';
 import { callWithTelemetryAndErrorHandlingSync, IActionContext, IParsedError, parseError } from 'vscode-azureextensionui';
 import { AzureAccountExtensionApi, AzureLoginStatus, AzureSession, CloudShell, CloudShellStatus, UploadOptions } from '../azure-account.api';
 import { AzureSession as AzureSessionLegacy } from '../azure-account.legacy.api';
@@ -208,6 +208,7 @@ export function createCloudConsole(api: AzureAccountExtensionApi, osName: OSName
 			void commands.executeCommand('setContext', 'openCloudConsoleCount', `${shells.length}`);
 
 			const isWindows: boolean = process.platform === 'win32';
+			const isWeb: boolean = env.uiKind === UIKind.Web;
 			if (isWindows) {
 				// See below
 				try {
@@ -273,7 +274,7 @@ export function createCloudConsole(api: AzureAccountExtensionApi, osName: OSName
 				shellArgs.shift();
 			}
 
-			if (!isWindows && semver.gte(version, '1.62.1')) {
+			if (!isWindows && !isWeb && semver.gte(version, '1.62.1')) {
 				// https://github.com/microsoft/vscode/issues/136987
 				// This fix can't be applied to all versions of VS Code. An error is thrown in versions less than the one specified
 				shellArgs.push('--ms-enable-electron-run-as-node');


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/391

This issue was caused by https://github.com/microsoft/vscode-azure-account/pull/357 which was the fix for https://github.com/microsoft/vscode/issues/136987. Turns out that Linux doesn't like the `ms-enable-electron-run-as-node` flag along with Windows. And both Codespaces and WSL are Linux products so that explains https://github.com/microsoft/vscode-azure-account/issues/391.

