### PR TITLE
Switch to latest VM image for mac builds

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -24,7 +24,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: macOS-10.14 # Using 10.14 instead of latest (10.15) because of "ENOTCONN" errors during tests
+    vmImage: macOS-latest
   steps:
   - template: common/build.yml
   - template: common/package.yml


### PR DESCRIPTION
This fixes the mac pipeline which had been failing for a bit because the hard coded image is longer available.

> An image label with the label macOS-10.14 does not exist. ([source](https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=42546&view=logs&j=a5e52b91-c83f-5429-4a68-c246fc63a4f7))