### PR TITLE
Add 'experimental' tag to auth library setting for easier A/B testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,7 +233,9 @@
                     ],
                     "description": "The authentication library to use. Note: You must sign out and reload the window after modifying this setting for it to take effect.",
                     "default": "ADAL",
-                    "tags": ["experimental"]
+                    "tags": [
+                        "experimental"
+                    ]
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -231,7 +231,9 @@
                         "Azure Active Directory Authentication Library",
                         "Microsoft Authentication Library (Preview)"
                     ],
-                    "description": "The authentication library to use. The extension will choose a library for you if this setting is left blank. Note: You must sign out and reload the window after modifying this setting for it to take effect."
+                    "description": "The authentication library to use. Note: You must sign out and reload the window after modifying this setting for it to take effect.",
+                    "default": "ADAL",
+                    "tags": ["experimental"]
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,6 @@ export async function activateInternal(context: ExtensionContext, perfStats: { l
 		activateContext.telemetry.properties.activationTime = String((perfStats.loadEndTime - perfStats.loadStartTime) / 1000);
 
 		ext.experimentationService = await createExperimentationService(context);
-		ext.isMsalTreatmentVariable = await ext.experimentationService.getCachedTreatmentVariable('azure-account.isMsal');
 		ext.loginHelper = new AzureAccountLoginHelper(context);
 
 		await migrateEnvironmentSetting();

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -14,5 +14,4 @@ export namespace ext {
     export let outputChannel: IAzExtOutputChannel;
     export let uriEventHandler: UriEventHandler;
     export let experimentationService: IExperimentationServiceAdapter;
-    export let isMsalTreatmentVariable: boolean | undefined;
 }

--- a/src/login/getAuthLibrary.ts
+++ b/src/login/getAuthLibrary.ts
@@ -5,29 +5,17 @@
 
 import { callWithTelemetryAndErrorHandlingSync, IActionContext } from "vscode-azureextensionui";
 import { AuthLibrary, authLibrarySetting } from "../constants";
-import { ext } from "../extensionVariables";
 import { getSettingValue } from "../utils/settingUtils";
 
 export function getAuthLibrary(): AuthLibrary {
 	return callWithTelemetryAndErrorHandlingSync('getAuthLibrary', (context: IActionContext) => {
-		let authLibrary: AuthLibrary | undefined = getSettingValue<AuthLibrary>(authLibrarySetting);
-
-		switch (authLibrary) {
-			case 'MSAL':
-				context.telemetry.properties.authLibrarySetting = 'MSAL';
-				break;
-			case 'ADAL':
-				context.telemetry.properties.authLibrarySetting = 'ADAL';
-				break;
-			default:
-				context.telemetry.properties.authLibrarySetting = 'undefined';
-				if (ext.isMsalTreatmentVariable) {
-					authLibrary = 'MSAL';
-				} else {
-					authLibrary = 'ADAL';
-				}
+		let authLibrary: AuthLibrary | undefined = getSettingValue(authLibrarySetting);
+		if (!authLibrary) {
+			authLibrary = 'ADAL';
+			context.telemetry.properties.failedToReadAuthLibrarySetting = 'true';
 		}
 
+		context.telemetry.properties.authLibrarySetting = authLibrary;
 		return authLibrary;
 	}) as AuthLibrary;
 }


### PR DESCRIPTION
This leans on VS Code's support for [experimental settings](https://github.com/microsoft/vscode/issues/134684). I removed the old `azure-account.isMsal` treatment variable. We'll have to reconfigure our A/B test to use the `azure.authenticationLibrary` setting.