### PR TITLE
Suppress credscan for suspected password found in extension.bundle.js.map

### DIFF
--- a/.azure-pipelines/compliance/CredScanSuppressions.json
+++ b/.azure-pipelines/compliance/CredScanSuppressions.json
@@ -4,6 +4,10 @@
         {
             "folder": "node_modules\\",
             "_justification": "No need to scan external node modules."
+        },
+        {
+            "hash": "/emif90WUK+sGxnCor3kHmrhC65OTPF+7TZ0cEkqHbc=",
+            "_justification": "The suspected secret was found in extension.bundle.js.map. It does not appear in the extension's source code or in any code that is shipped to customers as part of the VSIX."
         }
     ]
 }

--- a/.azure-pipelines/compliance/CredScanSuppressions.json
+++ b/.azure-pipelines/compliance/CredScanSuppressions.json
@@ -6,8 +6,8 @@
             "_justification": "No need to scan external node modules."
         },
         {
-            "hash": "/emif90WUK+sGxnCor3kHmrhC65OTPF+7TZ0cEkqHbc=",
-            "_justification": "The suspected secret was found in extension.bundle.js.map. It does not appear in the extension's source code or in any code that is shipped to customers as part of the VSIX."
+            "folder": "dist\\",
+            "_justification": "This folder is home to webpacked code, build artifacts, and dependencies: not source code."
         }
     ]
 }


### PR DESCRIPTION
I searched for the culprit for this credscan hit and was unable to find it. I argue that it's OK to suppress for the reasons listed in `_justification`.