### PR TITLE
Add clarifying comment to `PublicClientCredential`

### DIFF
--- a/src/login/msal/PublicClientCredential.ts
+++ b/src/login/msal/PublicClientCredential.ts
@@ -9,6 +9,7 @@ import { AccountInfo, AuthenticationResult, PublicClientApplication } from "@azu
 import { AzExtServiceClientCredentials } from "vscode-azureextensionui";
 import { defaultMsalScopes } from "../../constants";
 
+// Implements `AzExtServiceClientCredentials` for backwards compatibility with dependents that still rely on `signRequest`
 export class PublicClientCredential implements TokenCredential, AzExtServiceClientCredentials {
 	private publicClientApp: PublicClientApplication;
 	private accountInfo: AccountInfo;


### PR DESCRIPTION
@nturinski suggested adding this and I think it's helpful especially since we don't publicize our support for `AzExtServiceClientCredentials` in the API.