### PR TITLE
Update when `ms-enable-electron-run-as-node` flag is added to cloud shell process

### DIFF
--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -273,7 +273,7 @@ export function createCloudConsole(api: AzureAccountExtensionApi, osName: OSName
 				shellArgs.shift();
 			}
 
-			if (process.platform === 'darwin' || process.platform === 'linux' && env.uiKind === UIKind.Desktop && semver.gte(version, '1.62.1')) {
+			if (!isWindows && env.uiKind === UIKind.Desktop && semver.gte(version, '1.62.1')) {
 				// https://github.com/microsoft/vscode/issues/136987
 				// This fix can't be applied to all versions of VS Code. An error is thrown in versions less than the one specified
 				shellArgs.push('--ms-enable-electron-run-as-node');

--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import * as semver from 'semver';
 import { parse, UrlWithStringQuery } from 'url';
 import { v4 as uuid } from 'uuid';
-import { CancellationToken, commands, Disposable, env, EventEmitter, MessageItem, QuickPickItem, Terminal, TerminalOptions, TerminalProfile, ThemeIcon, Uri, version, window } from 'vscode';
+import { CancellationToken, commands, Disposable, env, EventEmitter, MessageItem, QuickPickItem, Terminal, TerminalOptions, TerminalProfile, ThemeIcon, UIKind, Uri, version, window } from 'vscode';
 import { callWithTelemetryAndErrorHandlingSync, IActionContext, IParsedError, parseError } from 'vscode-azureextensionui';
 import { AzureAccountExtensionApi, AzureLoginStatus, AzureSession, CloudShell, CloudShellStatus, UploadOptions } from '../azure-account.api';
 import { AzureSession as AzureSessionLegacy } from '../azure-account.legacy.api';
@@ -273,7 +273,7 @@ export function createCloudConsole(api: AzureAccountExtensionApi, osName: OSName
 				shellArgs.shift();
 			}
 
-			if (process.platform === 'darwin' && semver.gte(version, '1.62.1')) {
+			if (process.platform === 'darwin' || process.platform === 'linux' && env.uiKind === UIKind.Desktop && semver.gte(version, '1.62.1')) {
 				// https://github.com/microsoft/vscode/issues/136987
 				// This fix can't be applied to all versions of VS Code. An error is thrown in versions less than the one specified
 				shellArgs.push('--ms-enable-electron-run-as-node');


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/391

Codespaces running in web (Linux OS) *does not* need the flag while normal Linux running on desktop *does* need the flag. 

This gets messy because Codespaces running locally *does not* need the flag but as far as I can tell there isn't a way to know when the extension is being run from local Codespaces. VS Code's `appHost` and `uiKind` both read as `desktop` in this situation. 
So I'm making the conscious decision to not support cloud shell on local Codespaces because it doesn't seem worth the investigation time. With this change, we'll support cloud shell on Windows, Mac, Linux, and Codespaces Web.

For context, here's the flag requirements I gathered from my testing:

| Platform | Flag required? |
|-|:-:|
|Windows|❌|
|Mac|✅|
|Linux|✅|
|Codespaces (Linux) Web|❌|
|Codespaces (Linux) Local|❌|

And any time the flag is included where it isn't needed a big nasty error is shown (see above issue).