### PR TITLE
Prompt to sign out and reload window if the auth library changed since last session

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,8 @@
                     "default": "ADAL",
                     "tags": [
                         "experimental"
-                    ]
+                    ],
+                    "scope": "machine-overridable"
                 }
             }
         }

--- a/src/login/AuthLibraryCache.ts
+++ b/src/login/AuthLibraryCache.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AuthLibrary } from "../constants";
+
+export const authLibraryCacheKey: string = 'authLibraryCache';
+
+export interface AuthLibraryCache {
+    lastUsedAuthLibrary: AuthLibrary | undefined;
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/433

Thanks @bwateratmsft for the investigation you did on this one. 

This change adds caching for the last seen auth library setting. At startup, it compares that value to the current auth library and if they're different, the extension prompts the user to sign out & reload the window.

I also added the machine-overridable scope to the auth library setting as suggested in https://github.com/microsoft/vscode-azure-account/issues/433#issuecomment-1036348207.