### PR TITLE
Revert VS Code engine to ^1.58.0 and onboard `@microsoft/vscode-azext-utils` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@azure/ms-rest-js": "^2.6.0",
                 "@azure/ms-rest-nodeauth": "^3.0.10",
                 "@azure/msal-node": "^1.3.0",
+                "@microsoft/vscode-azext-utils": "^0.1.0",
                 "adal-node": "^0.2.3",
                 "form-data": "2.3.3",
                 "http-proxy-agent": "2.1.0",
@@ -26,7 +27,6 @@
                 "request-promise": "4.2.2",
                 "semver": "5.6.0",
                 "uuid": "^8.3.2",
-                "vscode-azureextensionui": "^0.49.1",
                 "vscode-nls": "4.0.0",
                 "ws": "7.4.6"
             },
@@ -84,49 +84,6 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@azure/arm-resources/-/arm-resources-4.2.2.tgz",
             "integrity": "sha512-Oic1OcEwgex3X1KkhP9UM/E/taIaS9oID7PL/CZ8knD7qtVNSRvTxP3uvD3ZpH9NYBYXngJsX5xyRu66iFN+rA==",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/@azure/arm-resources-profile-2020-09-01-hybrid": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-profile-2020-09-01-hybrid/-/arm-resources-profile-2020-09-01-hybrid-1.1.1.tgz",
-            "integrity": "sha512-6Ku548pHIQULuXzQrxe4zBCxi2g+JBf4bk4HZyYwmyV1ai4ZawDzS8pN/gREhSxeV/t6KtpmHMADi5oxc7wqaA==",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/@azure/arm-resources-subscriptions": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-1.0.1.tgz",
-            "integrity": "sha512-aEn2DGAhzGoteEvawnZlP4ATPo2FEyhQHUucDUz7vIaAarPb6CY4T8w+1SJt/SkIN/ZxwvLcFAhv28Tm0mhxXw==",
-            "dependencies": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/@azure/arm-storage": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-15.3.0.tgz",
-            "integrity": "sha512-djN2tmEzvC4lNEYrk3PAXkf5ZcebGDqPZSh/cYKOleumD4eop5EpMX8d5LcSO/9EcSfPpCzutRg0AleMaPQ9Mg==",
-            "dependencies": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
-                "tslib": "^1.10.0"
-            }
-        },
-        "node_modules/@azure/arm-storage-profile-2020-09-01-hybrid": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage-profile-2020-09-01-hybrid/-/arm-storage-profile-2020-09-01-hybrid-1.1.1.tgz",
-            "integrity": "sha512-GgsnN8eWctoOvix0vr1RQI/DrBpcR5mIOZ/4FIdJgsIapg6ZWPIYmLYfAyvelfC+KVsEqOGRMTQY5UZ4b9et/A==",
             "dependencies": {
                 "@azure/core-auth": "^1.1.4",
                 "@azure/ms-rest-azure-js": "^2.1.0",
@@ -442,6 +399,42 @@
                 "eslint": ">=7",
                 "eslint-plugin-import": ">=2"
             }
+        },
+        "node_modules/@microsoft/vscode-azext-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.1.0.tgz",
+            "integrity": "sha512-HJGh8eXP5pJ+d9Fp+3BLsZ29NK20/86sWQ/OAeKwV2W+J8JiiDJmZvNapC/G3MrMpb8tcD4KthAl0mJDo0o6gw==",
+            "dependencies": {
+                "@vscode/extension-telemetry": "^0.4.7",
+                "dayjs": "^1.9.3",
+                "escape-string-regexp": "^2.0.0",
+                "html-to-text": "^5.1.1",
+                "open": "^8.0.4",
+                "semver": "^5.7.1",
+                "vscode-nls": "^4.1.1",
+                "vscode-tas-client": "^0.1.22"
+            }
+        },
+        "node_modules/@microsoft/vscode-azext-utils/node_modules/escape-string-regexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@microsoft/vscode-azext-utils/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/@microsoft/vscode-azext-utils/node_modules/vscode-nls": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
+            "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -1208,6 +1201,14 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@vscode/extension-telemetry": {
+            "version": "0.4.9",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.4.9.tgz",
+            "integrity": "sha512-ZQIqlcgJU462oyQJDVgmEKNSSibEp1CRs0ECoa43gwgkt877Jm2dpz5G+KQhXad/zJy1sxTq8r/5kD75nq4W8Q==",
+            "engines": {
+                "vscode": "^1.60.0"
             }
         },
         "node_modules/@webassemblyjs/ast": {
@@ -11426,58 +11427,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/vscode-azureextensionui": {
-            "version": "0.49.1",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.1.tgz",
-            "integrity": "sha512-+DxY6iQrbFhG+Vsz0y16VMrM6bHSlQWUDRquD4sLY0HgeSHoB1E+bQqR7UrQKm8mhInz2XvovzRPW3U6UNgzcw==",
-            "dependencies": {
-                "@azure/arm-resources": "^4.0.0",
-                "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/arm-resources-subscriptions": "^1.0.0",
-                "@azure/arm-storage": "^15.0.0",
-                "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/ms-rest-azure-env": "^2.0.0",
-                "@azure/ms-rest-js": "^2.2.1",
-                "dayjs": "^1.9.3",
-                "escape-string-regexp": "^2.0.0",
-                "html-to-text": "^5.1.1",
-                "open": "^8.0.4",
-                "semver": "^5.7.1",
-                "uuid": "^8.3.2",
-                "vscode-extension-telemetry": "^0.4.3",
-                "vscode-nls": "^4.1.1",
-                "vscode-tas-client": "^0.1.22"
-            }
-        },
-        "node_modules/vscode-azureextensionui/node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/vscode-azureextensionui/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/vscode-azureextensionui/node_modules/vscode-nls": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-            "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
-        },
-        "node_modules/vscode-extension-telemetry": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.5.tgz",
-            "integrity": "sha512-YhPiPcelqM5xyYWmD46jIcsxLYWkPZhAxlBkzqmpa218fMtTT17ERdOZVCXcs1S5AjvDHlq43yCgi8TaVQjjEg==",
-            "engines": {
-                "vscode": "^1.60.0"
-            }
-        },
         "node_modules/vscode-nls": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.0.0.tgz",
@@ -12067,49 +12016,6 @@
                 "tslib": "^1.10.0"
             }
         },
-        "@azure/arm-resources-profile-2020-09-01-hybrid": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-profile-2020-09-01-hybrid/-/arm-resources-profile-2020-09-01-hybrid-1.1.1.tgz",
-            "integrity": "sha512-6Ku548pHIQULuXzQrxe4zBCxi2g+JBf4bk4HZyYwmyV1ai4ZawDzS8pN/gREhSxeV/t6KtpmHMADi5oxc7wqaA==",
-            "requires": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
-        "@azure/arm-resources-subscriptions": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-resources-subscriptions/-/arm-resources-subscriptions-1.0.1.tgz",
-            "integrity": "sha512-aEn2DGAhzGoteEvawnZlP4ATPo2FEyhQHUucDUz7vIaAarPb6CY4T8w+1SJt/SkIN/ZxwvLcFAhv28Tm0mhxXw==",
-            "requires": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
-        "@azure/arm-storage": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-15.3.0.tgz",
-            "integrity": "sha512-djN2tmEzvC4lNEYrk3PAXkf5ZcebGDqPZSh/cYKOleumD4eop5EpMX8d5LcSO/9EcSfPpCzutRg0AleMaPQ9Mg==",
-            "requires": {
-                "@azure/ms-rest-azure-js": "^2.0.1",
-                "@azure/ms-rest-js": "^2.0.4",
-                "tslib": "^1.10.0"
-            }
-        },
-        "@azure/arm-storage-profile-2020-09-01-hybrid": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage-profile-2020-09-01-hybrid/-/arm-storage-profile-2020-09-01-hybrid-1.1.1.tgz",
-            "integrity": "sha512-GgsnN8eWctoOvix0vr1RQI/DrBpcR5mIOZ/4FIdJgsIapg6ZWPIYmLYfAyvelfC+KVsEqOGRMTQY5UZ4b9et/A==",
-            "requires": {
-                "@azure/core-auth": "^1.1.4",
-                "@azure/ms-rest-azure-js": "^2.1.0",
-                "@azure/ms-rest-js": "^2.2.0",
-                "tslib": "^1.10.0"
-            }
-        },
         "@azure/arm-subscriptions": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@azure/arm-subscriptions/-/arm-subscriptions-3.1.2.tgz",
@@ -12369,6 +12275,38 @@
             "dev": true,
             "requires": {
                 "@typescript-eslint/parser": "^4.28.5"
+            }
+        },
+        "@microsoft/vscode-azext-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.1.0.tgz",
+            "integrity": "sha512-HJGh8eXP5pJ+d9Fp+3BLsZ29NK20/86sWQ/OAeKwV2W+J8JiiDJmZvNapC/G3MrMpb8tcD4KthAl0mJDo0o6gw==",
+            "requires": {
+                "@vscode/extension-telemetry": "^0.4.7",
+                "dayjs": "^1.9.3",
+                "escape-string-regexp": "^2.0.0",
+                "html-to-text": "^5.1.1",
+                "open": "^8.0.4",
+                "semver": "^5.7.1",
+                "vscode-nls": "^4.1.1",
+                "vscode-tas-client": "^0.1.22"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                },
+                "vscode-nls": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
+                    "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
+                }
             }
         },
         "@nodelib/fs.scandir": {
@@ -12988,6 +12926,11 @@
                 "@typescript-eslint/types": "4.33.0",
                 "eslint-visitor-keys": "^2.0.0"
             }
+        },
+        "@vscode/extension-telemetry": {
+            "version": "0.4.9",
+            "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.4.9.tgz",
+            "integrity": "sha512-ZQIqlcgJU462oyQJDVgmEKNSSibEp1CRs0ECoa43gwgkt877Jm2dpz5G+KQhXad/zJy1sxTq8r/5kD75nq4W8Q=="
         },
         "@webassemblyjs/ast": {
             "version": "1.11.1",
@@ -21014,51 +20957,6 @@
                     }
                 }
             }
-        },
-        "vscode-azureextensionui": {
-            "version": "0.49.1",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.49.1.tgz",
-            "integrity": "sha512-+DxY6iQrbFhG+Vsz0y16VMrM6bHSlQWUDRquD4sLY0HgeSHoB1E+bQqR7UrQKm8mhInz2XvovzRPW3U6UNgzcw==",
-            "requires": {
-                "@azure/arm-resources": "^4.0.0",
-                "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/arm-resources-subscriptions": "^1.0.0",
-                "@azure/arm-storage": "^15.0.0",
-                "@azure/arm-storage-profile-2020-09-01-hybrid": "^1.0.0",
-                "@azure/ms-rest-azure-env": "^2.0.0",
-                "@azure/ms-rest-js": "^2.2.1",
-                "dayjs": "^1.9.3",
-                "escape-string-regexp": "^2.0.0",
-                "html-to-text": "^5.1.1",
-                "open": "^8.0.4",
-                "semver": "^5.7.1",
-                "uuid": "^8.3.2",
-                "vscode-extension-telemetry": "^0.4.3",
-                "vscode-nls": "^4.1.1",
-                "vscode-tas-client": "^0.1.22"
-            },
-            "dependencies": {
-                "escape-string-regexp": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                },
-                "vscode-nls": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
-                    "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
-                }
-            }
-        },
-        "vscode-extension-telemetry": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.5.tgz",
-            "integrity": "sha512-YhPiPcelqM5xyYWmD46jIcsxLYWkPZhAxlBkzqmpa218fMtTT17ERdOZVCXcs1S5AjvDHlq43yCgi8TaVQjjEg=="
         },
         "vscode-nls": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -292,6 +292,7 @@
         "@azure/ms-rest-js": "^2.6.0",
         "@azure/ms-rest-nodeauth": "^3.0.10",
         "@azure/msal-node": "^1.3.0",
+        "@microsoft/vscode-azext-utils": "^0.1.0",
         "adal-node": "^0.2.3",
         "form-data": "2.3.3",
         "http-proxy-agent": "2.1.0",
@@ -302,7 +303,6 @@
         "request-promise": "4.2.2",
         "semver": "5.6.0",
         "uuid": "^8.3.2",
-        "vscode-azureextensionui": "^0.49.1",
         "vscode-nls": "4.0.0",
         "ws": "7.4.6"
     }

--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { callWithTelemetryAndErrorHandlingSync, IActionContext, IParsedError, parseError } from '@microsoft/vscode-azext-utils';
 import * as cp from 'child_process';
 import * as FormData from 'form-data';
 import { ReadStream } from 'fs';
@@ -15,7 +16,6 @@ import * as semver from 'semver';
 import { parse, UrlWithStringQuery } from 'url';
 import { v4 as uuid } from 'uuid';
 import { CancellationToken, commands, Disposable, env, EventEmitter, MessageItem, QuickPickItem, Terminal, TerminalOptions, TerminalProfile, ThemeIcon, UIKind, Uri, version, window } from 'vscode';
-import { callWithTelemetryAndErrorHandlingSync, IActionContext, IParsedError, parseError } from 'vscode-azureextensionui';
 import { AzureAccountExtensionApi, AzureLoginStatus, AzureSession, CloudShell, CloudShellStatus, UploadOptions } from '../azure-account.api';
 import { AzureSession as AzureSessionLegacy } from '../azure-account.legacy.api';
 import { ext } from '../extensionVariables';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, createExperimentationService, IActionContext, registerReportIssueCommand, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
+import { AzureExtensionApiProvider } from '@microsoft/vscode-azext-utils/api';
 import { createReadStream } from 'fs';
 import { basename } from 'path';
 import { CancellationToken, commands, ConfigurationTarget, env, ExtensionContext, ProgressLocation, Uri, window, workspace, WorkspaceConfiguration } from 'vscode';
-import { callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, createExperimentationService, IActionContext, registerReportIssueCommand, registerUIExtensionVariables } from 'vscode-azureextensionui';
-import { AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { AzureAccountExtensionApi } from './azure-account.api';
 import { createCloudConsole, OSes, OSName, shells } from './cloudConsole/cloudConsole';
 import { AuthLibrary, authLibrarySetting, cloudSetting, displayName, extensionPrefix, showSignedInEmailSetting } from './constants';

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IAzExtOutputChannel, IExperimentationServiceAdapter } from "@microsoft/vscode-azext-utils";
 import { ExtensionContext } from "vscode";
-import { IAzExtOutputChannel, IExperimentationServiceAdapter } from "vscode-azureextensionui";
 import { AzureAccountLoginHelper } from "./login/AzureLoginHelper";
 import { UriEventHandler } from "./login/exchangeCodeForToken";
 

--- a/src/login/AuthProviderBase.ts
+++ b/src/login/AuthProviderBase.ts
@@ -6,11 +6,11 @@
 import { TokenCredential } from "@azure/core-auth";
 import { Environment } from "@azure/ms-rest-azure-env";
 import { AccountInfo } from "@azure/msal-node";
+import { parseError } from "@microsoft/vscode-azext-utils";
 import { randomBytes } from "crypto";
 import { ServerResponse } from "http";
 import { DeviceTokenCredentials } from "ms-rest-azure";
 import { env, MessageItem, UIKind, Uri, window } from "vscode";
-import { parseError } from "vscode-azureextensionui";
 import { AzureAccountExtensionApi, AzureSession } from "../azure-account.api";
 import { redirectUrlAAD, redirectUrlADFS } from "../constants";
 import { localize } from "../utils/localize";

--- a/src/login/AzureAccountExtensionApi.ts
+++ b/src/login/AzureAccountExtensionApi.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { callWithTelemetryAndErrorHandling, IActionContext } from '@microsoft/vscode-azext-utils';
 import { Disposable, Event } from 'vscode';
-import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import * as types from '../azure-account.api';
 import { createCloudConsole, OSName } from '../cloudConsole/cloudConsole';
 import { AzureAccountLoginHelper } from './AzureLoginHelper';

--- a/src/login/AzureLoginHelper.ts
+++ b/src/login/AzureLoginHelper.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Environment } from '@azure/ms-rest-azure-env';
+import { callWithTelemetryAndErrorHandling, IActionContext } from '@microsoft/vscode-azext-utils';
 import { CancellationTokenSource, commands, EventEmitter, ExtensionContext, MessageItem, window, workspace } from 'vscode';
-import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import { AzureLoginStatus, AzureResourceFilter, AzureSession, AzureSubscription } from '../azure-account.api';
 import { AuthLibrary, authLibrarySetting, cacheKey, clientId, cloudSetting, commonTenantId, customCloudArmUrlSetting, resourceFilterSetting, tenantSetting } from '../constants';
 import { AzureLoginError, getErrorMessage } from '../errors';

--- a/src/login/commands/selectSubscriptions.ts
+++ b/src/login/commands/selectSubscriptions.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { callWithTelemetryAndErrorHandling, IActionContext } from "@microsoft/vscode-azext-utils";
 import { CancellationTokenSource, commands, ConfigurationTarget, QuickPickItem, window, workspace, WorkspaceConfiguration } from "vscode";
-import { callWithTelemetryAndErrorHandling, IActionContext } from "vscode-azureextensionui";
 import { AzureSubscription } from "../../azure-account.api";
 import { extensionPrefix, resourceFilterSetting } from "../../constants";
 import { ext } from "../../extensionVariables";

--- a/src/login/commands/selectTenant.ts
+++ b/src/login/commands/selectTenant.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { callWithTelemetryAndErrorHandling, IActionContext } from "@microsoft/vscode-azext-utils";
 import { window } from "vscode";
-import { callWithTelemetryAndErrorHandling, IActionContext } from "vscode-azureextensionui";
 import { tenantSetting } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";

--- a/src/login/getAuthLibrary.ts
+++ b/src/login/getAuthLibrary.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { callWithTelemetryAndErrorHandlingSync, IActionContext } from "vscode-azureextensionui";
+import { callWithTelemetryAndErrorHandlingSync, IActionContext } from "@microsoft/vscode-azext-utils";
 import { AuthLibrary, authLibrarySetting } from "../constants";
 import { getSettingValue } from "../utils/settingUtils";
 

--- a/src/login/msal/PublicClientCredential.ts
+++ b/src/login/msal/PublicClientCredential.ts
@@ -6,7 +6,7 @@
 import { AccessToken, TokenCredential } from "@azure/core-auth";
 import { Constants as MSRestConstants, WebResource } from "@azure/ms-rest-js";
 import { AccountInfo, AuthenticationResult, PublicClientApplication } from "@azure/msal-node";
-import { AzExtServiceClientCredentials } from "vscode-azureextensionui";
+import { AzExtServiceClientCredentials } from "@microsoft/vscode-azext-utils";
 import { defaultMsalScopes } from "../../constants";
 
 // Implements `AzExtServiceClientCredentials` for backwards compatibility with dependents that still rely on `signRequest`

--- a/src/login/updateSubscriptions.ts
+++ b/src/login/updateSubscriptions.ts
@@ -5,7 +5,7 @@
 
 import { SubscriptionClient } from "@azure/arm-subscriptions";
 import { HttpOperationResponse, RequestPrepareOptions } from "@azure/ms-rest-js";
-import { callWithTelemetryAndErrorHandling, IActionContext } from "vscode-azureextensionui";
+import { callWithTelemetryAndErrorHandling, IActionContext } from "@microsoft/vscode-azext-utils";
 import { AzureSubscription } from "../azure-account.api";
 import { cacheKey } from "../constants";
 import { ext } from "../extensionVariables";

--- a/src/nps.ts
+++ b/src/nps.ts
@@ -5,8 +5,8 @@
 
 'use strict';
 
+import { callWithTelemetryAndErrorHandling, IActionContext } from '@microsoft/vscode-azext-utils';
 import { env, ExtensionContext, extensions, Uri, window } from 'vscode';
-import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import * as nls from 'vscode-nls';
 
 const localize = nls.loadMessageBundle();

--- a/src/utils/logErrorMessage.ts
+++ b/src/utils/logErrorMessage.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { parseError } from "vscode-azureextensionui";
+import { parseError } from "@microsoft/vscode-azext-utils";
 import { ext } from "../extensionVariables";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types


### PR DESCRIPTION
I bumped the VS Code engine in https://github.com/microsoft/vscode-azure-account/pull/422 thinking it was required to switch to Node 14 but I was mistaken.