### PR TITLE
Make `scopes` argument optional for MSAL's `getToken`

### DIFF
--- a/src/login/msal/PublicClientCredential.ts
+++ b/src/login/msal/PublicClientCredential.ts
@@ -19,8 +19,12 @@ export class PublicClientCredential implements TokenCredential, AzExtServiceClie
 		this.accountInfo = accountInfo;
 	}
 
-	public async getToken(scopes: string | string[]): Promise<AccessToken | null> {
-		scopes = Array.isArray(scopes) ? scopes : [scopes];
+	public async getToken(scopes?: string | string[]): Promise<AccessToken | null> {
+		if (scopes) {
+			scopes = Array.isArray(scopes) ? scopes : [scopes];
+		} else {
+			scopes = [];
+		}
 
 		if (scopes.length === 1 && scopes[0] === 'https://management.azure.com/.default') {
 			// The Azure Functions & App Service APIs only accept the legacy scope (which is the default scope we use)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/457 sort of.

This problem was related to MSAL and how `getToken` required a `scopes` parameter. Now `getToken` will successfully return an access token in this case. 

There's a problem with the new token though: it doesn't appear to have the correct scope(s) required for the ML extension to open a compute instance and this error is produced:

<img width="459" alt="Screen Shot 2022-02-18 at 8 56 09 AM" src="https://user-images.githubusercontent.com/22795803/154727569-1c7d4e14-e97f-4a37-a14a-33a17b3fb516.png">

It should be on the API users to hunt down the proper scopes required in the `getToken` call. We cannot & should not include all the scopes every extension needs in every token request. But finding the right scopes is a task that I wouldn't wish on my worst enemy. So we'll need to work with the MSAL team to figure out how to make that suck less for our API users.