### PR TITLE
Use the proper setting key when updating cloud setting

### DIFF
--- a/src/login/commands/loginToCloud.ts
+++ b/src/login/commands/loginToCloud.ts
@@ -56,7 +56,7 @@ export async function loginToCloud(): Promise<void> {
 				}
 				await config.update(tenantSetting, tenantId, getCurrentTarget(config.inspect(tenantSetting)));
 				// if outside of normal range, set ppe setting
-				await config.update(tenantSetting, selected.environment.name, getCurrentTarget(config.inspect(cloudSetting)));
+				await config.update(cloudSetting, selected.environment.name, getCurrentTarget(config.inspect(cloudSetting)));
 			} else {
 				return;
 			}


### PR DESCRIPTION
The tenant setting was being updated when it should have been updating the cloud setting. This was the culprit for issues like this where an incorrect tenant ID was being used to sign in:
![Screen Shot 2022-02-18 at 10 16 23 AM](https://user-images.githubusercontent.com/22795803/154739723-c1a9dbfb-9be1-44fb-97e8-7c32d959a939.png)

