### PR TITLE
Tenant setting-related changes

### DIFF
--- a/src/login/commands/loginToCloud.ts
+++ b/src/login/commands/loginToCloud.ts
@@ -50,7 +50,7 @@ export async function loginToCloud(): Promise<void> {
 				prompt: localize('azure-account.enterTenantId', "Enter the tenant id"),
 				placeHolder: localize('azure-account.tenantIdPlaceholder', "Enter your tenant id, or '{0}' for the default tenant", commonTenantId),
 				ignoreFocusOut: true});
-			if (tenantId) {
+			if (tenantId !== undefined) {
 				if (armUrl) {
 					await config.update(customCloudArmUrlSetting, armUrl, getCurrentTarget(config.inspect(customCloudArmUrlSetting)));
 				}

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -5,6 +5,7 @@
 
 import { workspace, WorkspaceConfiguration } from "vscode";
 import { extensionPrefix } from "../constants";
+import { getCurrentTarget } from "../login/getCurrentTarget";
 
 export function getSettingWithPrefix(settingName: string): string {
 	return `${extensionPrefix}.${settingName}`;
@@ -17,5 +18,5 @@ export function getSettingValue<T>(settingName: string): T | undefined {
 
 export async function updateSettingValue<T>(settingName: string, value: T): Promise<void> {
 	const config: WorkspaceConfiguration = workspace.getConfiguration(extensionPrefix);
-	await config.update(settingName, value);
+	await config.update(settingName, value, getCurrentTarget(config.inspect(settingName)));
 }


### PR DESCRIPTION
* Fix infinite loop in `loadTenants` when there's an error in the server response
* Finish running `Azure: Sign In to Azure Cloud` command even when the tenant ID is set to an empty string
* Get current target when updating setting value. This fixes the "Unable to write to Workspace Settings because no workspace is opened. Please open a workspace first and try again." error while running `Azure: Select Tenant` command