### PR TITLE
Changes to login and initialization

### DIFF
--- a/src/login/AuthProviderBase.ts
+++ b/src/login/AuthProviderBase.ts
@@ -32,7 +32,7 @@ export abstract class AuthProviderBase<TLoginResult> {
 
 	public abstract loginWithAuthCode(code: string, redirectUrl: string, clientId: string, environment: Environment, tenantId: string): Promise<TLoginResult>;
 	public abstract loginWithDeviceCode(environment: Environment, tenantId: string): Promise<TLoginResult>;
-	public abstract loginSilent(environment: Environment, tenantId: string, migrateToken?: boolean): Promise<TLoginResult>;
+	public abstract loginSilent(environment: Environment, tenantId: string): Promise<TLoginResult>;
 	public abstract getCredentials(environment: string, userId: string, tenantId: string): AbstractCredentials;
 	public abstract getCredentials2(environment: Environment, userId: string, tenantId: string, accountInfo?: AccountInfo): AbstractCredentials2;
 	public abstract updateSessions(environment: Environment, loginResult: TLoginResult, sessions: AzureSession[]): Promise<void>;

--- a/src/login/adal/AdalAuthProvider.ts
+++ b/src/login/adal/AdalAuthProvider.ts
@@ -64,8 +64,8 @@ export class AdalAuthProvider extends AuthProviderBase<TokenResponse[]> {
 		return getTokensFromToken(environment, tenantId, tokenResponse);
 	}
 
-	public async loginSilent(environment: Environment, tenantId: string, migrateToken?: boolean): Promise<TokenResponse[]> {
-		const storedCreds: string | undefined = await getStoredCredentials(environment, migrateToken);
+	public async loginSilent(environment: Environment, tenantId: string): Promise<TokenResponse[]> {
+		const storedCreds: string | undefined = await getStoredCredentials(environment);
 		if (!storedCreds) {
 			throw new AzureLoginError(localize('azure-account.refreshTokenMissing', 'Not signed in'));
 		}

--- a/src/login/adal/tokens.ts
+++ b/src/login/adal/tokens.ts
@@ -46,16 +46,14 @@ export class ProxyTokenCache {
 	/* eslint-enable */
 }
 
-export async function getStoredCredentials(environment: Environment, migrateToken?: boolean): Promise<string | undefined> {
+export async function getStoredCredentials(environment: Environment): Promise<string | undefined> {
 	try {
-		if (migrateToken) {
-			const token = await ext.context.secrets.get('Refresh Token');
-			if (token) {
-				if (!await ext.context.secrets.get('Azure')) {
-					await ext.context.secrets.store('Azure', token);
-				}
-				await ext.context.secrets.delete('Refresh Token');
+		const token = await ext.context.secrets.get('Refresh Token');
+		if (token) {
+			if (!await ext.context.secrets.get('Azure')) {
+				await ext.context.secrets.store('Azure', token);
 			}
+			await ext.context.secrets.delete('Refresh Token');
 		}
 	} catch {
 		// ignore


### PR DESCRIPTION
When testing https://github.com/microsoft/vscode-azure-account/pull/470 I noticed that switching between sovereign clouds while also changing the tenant using the `Azure: Sign In to Azure Cloud` command resulted in several errors ranging from cache read errors to "invalid grant".

This was happening because [this config watcher]( https://github.com/microsoft/vscode-azure-account/blob/36e0a4727655637eed6dd4ea84503e290f1fe660/src/login/AzureLoginHelper.ts#L74-L79) was activating twice: once for the cloud change and again for the tenant change. This was on top of the initialization function being called upon extension activation. These calls resulted in the cache being in a strange state when `loginSilent` was called and caused the above errors.

To fix this I force a logout before every login. This doesn't affect the API (it still shows the "signing in..." status) and it ensures the cache is clean before attempting to login with a new configuration. 