### PR TITLE
Change `azure.cloud` default to "AzureCloud" instead of "Azure"

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
                         "Azure US Government",
                         "Azure Custom Cloud"
                     ],
-                    "default": "Azure",
+                    "default": "AzureCloud",
                     "description": "The current Azure Cloud to connect to."
                 },
                 "azure.customCloud.resourceManagerEndpointUrl": {


### PR DESCRIPTION
Serene brought it to my attention that for a particular version of VS Code, "Azure" wasn't shown as an option for the `azure.cloud` setting:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/22795803/157152805-9bb7ee03-795e-46cd-a4e7-38e1e3ec401d.png)

In package.json, "Azure" (the default setting value) isn't actually included in the enum list:
https://github.com/microsoft/vscode-azure-account/blob/0231ca49f318a62b9ddf9174bd8bebd01b8a17e1/package.json#L143-L149

This led to the strange behavior in VS Code where "Azure" was sometimes shown in the list of potential Azure cloud setting values. This seems to have been done by mistake so I changed the default to "AzureCloud". 

I'm confident that this is an OK change after seeing the following function which is used to migrate from the old "Azure" cloud name to the new one ("AzureCloud"). So it turns out "Azure" was never actually being stored as a setting value for `azure.cloud`.

https://github.com/microsoft/vscode-azure-account/blob/0231ca49f318a62b9ddf9174bd8bebd01b8a17e1/src/extension.ts#L120-L138
