### PR TITLE
Don't use `parseError` in ipc.ts

### DIFF
--- a/src/cloudConsole/ipc.ts
+++ b/src/cloudConsole/ipc.ts
@@ -5,7 +5,6 @@
 
 'use strict';
 
-import { parseError } from '@microsoft/vscode-azext-utils';
 import * as crypto from 'crypto';
 import * as http from 'http';
 import * as os from 'os';
@@ -39,7 +38,7 @@ export class Server {
 	}
 
 	dispose(): void {
-		this.server.close(error => error && ext.outputChannel.appendLog(parseError(error).message));
+		this.server.close(error => error && error.message && ext.outputChannel.appendLog(error.message));
 	}
 }
 


### PR DESCRIPTION
The following error was being thrown on cloud shell startup for ADAL & MSAL regardless of Azure cloud type.

<img width="1171" alt="Screen Shot 2022-03-08 at 12 59 12 PM" src="https://user-images.githubusercontent.com/22795803/157326069-334241a8-c1c2-4446-8a5e-6c080d991df2.png">

It was happening because the following line I added pulls the whole UI package into the `cloudConsoleLauncher` entry point (configured [here](https://github.com/microsoft/vscode-azure-account/blob/0f33c01a1f8d0feb6469b1e700ebd73122964255/webpack.config.js#L20)). The cloud console launcher runs out of process and so it can't access the vscode API.

https://github.com/microsoft/vscode-azure-account/blob/0f33c01a1f8d0feb6469b1e700ebd73122964255/src/cloudConsole/ipc.ts#L42

Removing that single reference to `parseError` removes >20k likes of code from cloudConsoleLauncher.js and fixes this problem 😄