### PR TITLE
Only ask user to 'sign in again' after tenant change

### DIFF
--- a/src/login/commands/selectTenant.ts
+++ b/src/login/commands/selectTenant.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { window } from "vscode";
+import { commands, window } from "vscode";
 import { tenantSetting } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
@@ -39,11 +39,12 @@ export async function selectTenant(context: IActionContext): Promise<void> {
 		await updateSettingValue(tenantSetting, tenant);
 
 		if (ext.loginHelper.api.status === 'LoggedIn') {
-			const mustSignOut: string = localize('azure-account.mustSignOut', 'You must sign out and sign back in for tenant "{0}" to take effect.', tenant);
-			const signOut: string = localize('azure-account.signOut', 'Sign Out');
-			void window.showInformationMessage(mustSignOut, signOut).then(async value => {
-				if (value === signOut) {
-					await ext.loginHelper.logout(true /* forceLogout */);
+			const signInAgain: string = localize('azure-account.signInAgain', 'Sign in again for tenant "{0}" to take effect.', tenant);
+			const signIn: string = localize('azure-account.signIn', 'Sign In');
+			void window.showInformationMessage(signInAgain, signIn).then(async value => {
+				if (value === signIn) {
+					context.telemetry.properties.signInAgainAfterTenantChange = 'true';
+					await commands.executeCommand('azure-account.login');
 				}
 			});
 		}


### PR DESCRIPTION
Since a logout is forced before logging in (this is the case after the work in https://github.com/microsoft/vscode-azure-account/pull/472), this prompt was no longer accurate.