### PR TITLE
Log all URLs that the extension tries to reach

### DIFF
--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -19,6 +19,7 @@ import { CancellationToken, commands, Disposable, env, EventEmitter, MessageItem
 import { AzureAccountExtensionApi, AzureLoginStatus, AzureSession, CloudShell, CloudShellStatus, UploadOptions } from '../azure-account.api';
 import { AzureSession as AzureSessionLegacy } from '../azure-account.legacy.api';
 import { ext } from '../extensionVariables';
+import { logAttemptingToReachUrlMessage } from '../logAttemptingToReachUrlMessage';
 import { tokenFromRefreshToken } from '../login/adal/tokens';
 import { getAuthLibrary } from '../login/getAuthLibrary';
 import { localize } from '../utils/localize';
@@ -94,7 +95,9 @@ function getUploadFile(tokens: Promise<AccessTokens>, uris: Promise<ConsoleUris>
 				filename,
 				knownLength: options.contentLength
 			});
-			const uri: UrlWithStringQuery = parse(`${terminalUri}/upload`);
+			const uploadUri: string = `${terminalUri}/upload`;
+			logAttemptingToReachUrlMessage(uploadUri);
+			const uri: UrlWithStringQuery = parse(uploadUri);
 			const req: ClientRequest = form.submit(
 				{
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
@@ -403,6 +406,7 @@ export function createCloudConsole(api: AzureAccountExtensionApi, osName: OSName
 			const session: AzureSession = result.token.session;
 			const accessToken: string = result.token.accessToken;
 			const armEndpoint: string = session.environment.resourceManagerEndpointUrl;
+			logAttemptingToReachUrlMessage(armEndpoint);
 			const provisionTask: () => Promise<void> = async () => {
 				consoleUri = await provisionConsole(accessToken, armEndpoint, result.userSettings, OSes.Linux.id);
 				context.telemetry.properties.outcome = 'provisioned';

--- a/src/logAttemptingToReachUrlMessage.ts
+++ b/src/logAttemptingToReachUrlMessage.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ext } from "./extensionVariables";
+import { localize } from "./utils/localize";
+
+export function logAttemptingToReachUrlMessage(url: string): void {
+    ext.outputChannel.appendLog(localize('azure-account.attemptingToReachUrl', 'Attempting to reach URL "{0}"...', url));
+}

--- a/src/login/AuthProviderBase.ts
+++ b/src/login/AuthProviderBase.ts
@@ -14,6 +14,7 @@ import { CancellationToken, env, MessageItem, UIKind, Uri, window } from "vscode
 import { AzureAccountExtensionApi, AzureSession } from "../azure-account.api";
 import { redirectUrlAAD, redirectUrlADFS } from "../constants";
 import { ext } from "../extensionVariables";
+import { logAttemptingToReachUrlMessage } from "../logAttemptingToReachUrlMessage";
 import { localize } from "../utils/localize";
 import { logErrorMessage } from "../utils/logErrorMessage";
 import { openUri } from "../utils/openUri";
@@ -87,6 +88,9 @@ export abstract class AuthProviderBase<TLoginResult> {
 			const redirectUrl: string = isAdfs ? redirectUrlADFS : redirectUrlAAD;
 			const signInUrl: string = `${environment.activeDirectoryEndpointUrl}${isAdfs ? '' : `${tenantId}/`}oauth2/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUrl)}&state=${state}&resource=${encodeURIComponent(environment.activeDirectoryResourceId)}&prompt=select_account`;
 
+			logAttemptingToReachUrlMessage(redirectUrl);
+			logAttemptingToReachUrlMessage(signInUrl);
+
 			redirectResult.res.writeHead(302, { Location: signInUrl })
 			redirectResult.res.end();
 
@@ -122,6 +126,7 @@ export abstract class AuthProviderBase<TLoginResult> {
 		const callbackEnvironment: string = getCallbackEnvironment(callbackUri);
 		const state: string = `${callbackEnvironment}${port},${encodeURIComponent(nonce)},${encodeURIComponent(callbackUri.query)}`;
 		const signInUrl: string = `${environment.activeDirectoryEndpointUrl}${isAdfs ? '' : `${tenantId}/`}oauth2/authorize`;
+		logAttemptingToReachUrlMessage(signInUrl);
 		let uri: Uri = Uri.parse(signInUrl);
 		uri = uri.with({
 			query: `response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${redirectUrlAAD}&state=${state}&resource=${environment.activeDirectoryResourceId}&prompt=select_account`

--- a/src/login/waitUntilOnline.ts
+++ b/src/login/waitUntilOnline.ts
@@ -7,6 +7,7 @@ import { Environment } from "@azure/ms-rest-azure-env";
 import * as http from 'http';
 import * as https from 'https';
 import { CancellationTokenSource } from "vscode";
+import { logAttemptingToReachUrlMessage } from "../logAttemptingToReachUrlMessage";
 import { logErrorMessage } from "../utils/logErrorMessage";
 import { delay } from "../utils/timeUtils";
 
@@ -24,6 +25,7 @@ async function checkIsOnline(environment: Environment): Promise<boolean> {
 	try {
 		await new Promise<http.IncomingMessage>((resolve, reject) => {
 			const url: string = environment.activeDirectoryEndpointUrl;
+			logAttemptingToReachUrlMessage(url);
 			(url.startsWith('https:') ? https : http).get(url, resolve)
 				.on('error', reject);
 		});


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azure-account/issues/419

This PR specifically address this bullet from the above issue:

> Know which URLs the extension is attempting to hit so the user can configure their proxy accordingly. This could be done in the error notifications or in the logs.

I don't want to add a mechanism to turn off the "is this machine online" check for reasons listed in that issue.

I did my best to catch all the URLs and avoid too many duplicate URLs 🕵️‍♂️

Here's how the output channel looks during the sign in process:

<img width="1091" alt="Screen Shot 2022-03-16 at 2 58 21 PM" src="https://user-images.githubusercontent.com/22795803/158698154-af06ab68-41b8-481c-bac3-6302f44e64b1.png">


