### PR TITLE
Update moment to 2.29.2 to fix CVE-2022-24785

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7247,9 +7247,9 @@
             "dev": true
         },
         "node_modules/moment": {
-            "version": "2.29.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+            "version": "2.29.2",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+            "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
             "engines": {
                 "node": "*"
             }
@@ -17833,9 +17833,9 @@
             "dev": true
         },
         "moment": {
-            "version": "2.29.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+            "version": "2.29.2",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+            "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
         },
         "ms": {
             "version": "2.1.2",


### PR DESCRIPTION
Fixes [CVE-2022-24785](https://github.com/moment/moment/security/advisories/GHSA-8hfj-j24r-96c4)