### PR TITLE
Use new redirect server

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,9 +25,8 @@ export const cacheKey: string = 'cache';
 export const clientId: string = 'aebc6443-996d-45c2-90f0-388ff96faa56';
 export const commonTenantId: string = 'common';
 export const displayName: string = 'Azure Account';
-export const redirectUrlAAD: string = 'https://vscode-redirect.azurewebsites.net/';
 export const portADFS: number = 19472;
-export const redirectUrlADFS: string = `http://127.0.0.1:${portADFS}/callback`;
+export const redirectUrlAAD: string = 'https://vscode.dev/redirect';
 export const stoppedAuthTaskMessage: string = localize('azure-account.stoppedAuthTask', 'Stopped authentication task.');
 
 export const staticEnvironments: Environment[] = [

--- a/src/login/AuthProviderBase.ts
+++ b/src/login/AuthProviderBase.ts
@@ -12,7 +12,7 @@ import { ServerResponse } from "http";
 import { DeviceTokenCredentials } from "ms-rest-azure";
 import { CancellationToken, env, MessageItem, UIKind, Uri, window } from "vscode";
 import { AzureAccountExtensionApi, AzureSession } from "../azure-account.api";
-import { redirectUrlAAD, redirectUrlADFS } from "../constants";
+import { portADFS, redirectUrlAAD } from "../constants";
 import { ext } from "../extensionVariables";
 import { logAttemptingToReachUrlMessage } from "../logAttemptingToReachUrlMessage";
 import { localize } from "../utils/localize";
@@ -22,12 +22,15 @@ import { DeviceTokenCredentials2 } from "./adal/DeviceTokenCredentials2";
 import { AzureSessionInternal } from "./AzureSessionInternal";
 import { getEnvironments } from "./environments";
 import { exchangeCodeForToken } from "./exchangeCodeForToken";
+import { getLocalCallbackUrl } from "./getCallbackUrl";
 import { getKey } from "./getKey";
 import { CodeResult, createServer, createTerminateServer, RedirectResult, startServer } from './server';
 import { SubscriptionTenantCache } from "./subscriptionTypes";
 
 export type AbstractCredentials = DeviceTokenCredentials;
 export type AbstractCredentials2 = DeviceTokenCredentials2 | TokenCredential;
+
+const redirectUrlADFS: string = getLocalCallbackUrl(portADFS);
 
 export abstract class AuthProviderBase<TLoginResult> {
 	private terminateServer: (() => Promise<void>) | undefined;
@@ -84,9 +87,9 @@ export abstract class AuthProviderBase<TLoginResult> {
 			const host: string = redirectResult.req.headers.host || '';
 			const updatedPortStr: string = (/^[^:]+:(\d+)$/.exec(Array.isArray(host) ? host[0] : host) || [])[1];
 			const updatedPort: number = updatedPortStr ? parseInt(updatedPortStr, 10) : port;
-			const state: string = `${updatedPort},${encodeURIComponent(nonce)}`;
+			const state: string = `${encodeURIComponent(getLocalCallbackUrl(updatedPort))}?nonce=${encodeURIComponent(nonce)}`;
 			const redirectUrl: string = isAdfs ? redirectUrlADFS : redirectUrlAAD;
-			const signInUrl: string = `${environment.activeDirectoryEndpointUrl}${isAdfs ? '' : `${tenantId}/`}oauth2/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUrl)}&state=${state}&resource=${encodeURIComponent(environment.activeDirectoryResourceId)}&prompt=select_account`;
+			const signInUrl: string = `${environment.activeDirectoryEndpointUrl}${isAdfs ? '' : `${tenantId}/`}oauth2/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUrl)}&state=${state}`;
 
 			logAttemptingToReachUrlMessage(redirectUrl);
 			logAttemptingToReachUrlMessage(signInUrl);
@@ -120,16 +123,19 @@ export abstract class AuthProviderBase<TLoginResult> {
 	}
 
 	public async loginWithoutLocalServer(clientId: string, environment: Environment, isAdfs: boolean, tenantId: string): Promise<TLoginResult> {
-		const callbackUri: Uri = await env.asExternalUri(Uri.parse(`${env.uriScheme}://ms-vscode.azure-account`));
+		let callbackUri: Uri = await env.asExternalUri(Uri.parse(`${env.uriScheme}://ms-vscode.azure-account`));
 		const nonce: string = randomBytes(16).toString('base64');
-		const port: string | number = (callbackUri.authority.match(/:([0-9]*)$/) || [])[1] || (callbackUri.scheme === 'https' ? 443 : 80);
-		const callbackEnvironment: string = getCallbackEnvironment(callbackUri);
-		const state: string = `${callbackEnvironment}${port},${encodeURIComponent(nonce)},${encodeURIComponent(callbackUri.query)}`;
+		const callbackQuery = new URLSearchParams(callbackUri.query);
+		callbackQuery.set('nonce', nonce);
+		callbackUri = callbackUri.with({
+			query: callbackQuery.toString()
+		});
+		const state = encodeURIComponent(callbackUri.toString(true));
 		const signInUrl: string = `${environment.activeDirectoryEndpointUrl}${isAdfs ? '' : `${tenantId}/`}oauth2/authorize`;
 		logAttemptingToReachUrlMessage(signInUrl);
 		let uri: Uri = Uri.parse(signInUrl);
 		uri = uri.with({
-			query: `response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${redirectUrlAAD}&state=${state}&resource=${environment.activeDirectoryResourceId}&prompt=select_account`
+			query: `response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${redirectUrlAAD}&state=${state}`
 		});
 		void env.openExternal(uri);
 
@@ -140,7 +146,7 @@ export abstract class AuthProviderBase<TLoginResult> {
 			}, 1000 * 60 * 5)
 		});
 
-		return await Promise.race([exchangeCodeForToken<TLoginResult>(this, clientId, environment, tenantId, redirectUrlAAD, state), timeoutPromise]);
+		return await Promise.race([exchangeCodeForToken<TLoginResult>(this, clientId, environment, tenantId, redirectUrlAAD, nonce), timeoutPromise]);
 	}
 
 	public async initializeSessions(cache: SubscriptionTenantCache, api: AzureAccountExtensionApi): Promise<Record<string, AzureSession>> {
@@ -174,24 +180,5 @@ export abstract class AuthProviderBase<TLoginResult> {
 			void env.clipboard.writeText(userCode);
 			await openUri(verificationUrl);
 		}
-	}
-}
-
-function getCallbackEnvironment(callbackUri: Uri): string {
-	if (callbackUri.authority.endsWith('.workspaces.github.com') || callbackUri.authority.endsWith('.github.dev')) {
-		return `${callbackUri.authority},`;
-	}
-
-	switch (callbackUri.authority) {
-		case 'online.visualstudio.com':
-			return 'vso,';
-		case 'online-ppe.core.vsengsaas.visualstudio.com':
-			return 'vsoppe,';
-		case 'online.dev.core.vsengsaas.visualstudio.com':
-			return 'vsodev,';
-		case 'canary.online.visualstudio.com':
-			return 'vsocanary,';
-		default:
-			return '';
 	}
 }

--- a/src/login/exchangeCodeForToken.ts
+++ b/src/login/exchangeCodeForToken.ts
@@ -6,6 +6,7 @@
 import { Environment } from "@azure/ms-rest-azure-env";
 import { Disposable, EventEmitter, Uri, UriHandler } from "vscode";
 import { ext } from "../extensionVariables";
+import { localize } from "../utils/localize";
 import { AuthProviderBase } from "./AuthProviderBase";
 
 export class UriEventHandler extends EventEmitter<Uri> implements UriHandler {
@@ -14,7 +15,7 @@ export class UriEventHandler extends EventEmitter<Uri> implements UriHandler {
 	}
 }
 
-export async function exchangeCodeForToken<TLoginResult>(authProvider: AuthProviderBase<TLoginResult>, clientId: string, environment: Environment, tenantId: string, callbackUri: string, state: string): Promise<TLoginResult> {
+export async function exchangeCodeForToken<TLoginResult>(authProvider: AuthProviderBase<TLoginResult>, clientId: string, environment: Environment, tenantId: string, callbackUri: string, nonce: string): Promise<TLoginResult> {
 	let uriEventListener: Disposable;
 	return new Promise((resolve: (value: TLoginResult) => void , reject) => {
 		uriEventListener = ext.uriEventHandler.event(async (uri: Uri) => {
@@ -23,9 +24,9 @@ export async function exchangeCodeForToken<TLoginResult>(authProvider: AuthProvi
 				const query = parseQuery(uri);
 				const code = query.code;
 
-				// Workaround double encoding issues of state
-				if (query.state !== state && decodeURIComponent(query.state) !== state) {
-					throw new Error('State does not match.');
+				// Workaround double encoding issues
+				if (query.nonce !== nonce && decodeURIComponent(query.nonce) !== nonce) {
+					throw new Error(localize('azure-account.nonceDoesNotMatch', 'Nonce does not match.'));
 				}
 				/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 

--- a/src/login/getCallbackUrl.ts
+++ b/src/login/getCallbackUrl.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export function getLocalCallbackUrl(port: number): string {
+    return `http://127.0.0.1:${port}/callback`;
+}

--- a/src/login/server.ts
+++ b/src/login/server.ts
@@ -16,6 +16,7 @@ import { ext } from '../extensionVariables';
 import { localize } from '../utils/localize';
 import { logErrorMessage } from '../utils/logErrorMessage';
 import { Deferred } from '../utils/promiseUtils';
+import { getLocalCallbackUrl } from './getCallbackUrl';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RedirectResult = { req: http.IncomingMessage, res: http.ServerResponse } | { err: any; res: http.ServerResponse; };
@@ -27,15 +28,16 @@ export async function checkRedirectServer(isAdfs: boolean): Promise<boolean> {
 	if (isAdfs) {
 		return true;
 	}
+	const testCallbackUrl: string = getLocalCallbackUrl(3333);
 	let timer: NodeJS.Timer | undefined;
 	const checkServerPromise = new Promise<boolean>(resolve => {
 		const req: http.ClientRequest = https.get({
-			...url.parse(`${redirectUrlAAD}?state=3333,cccc`),
+			...url.parse(`${redirectUrlAAD}?state=${testCallbackUrl}?nonce=cccc`),
 		}, res => {
 			const key: string | undefined = Object.keys(res.headers)
 				.find(key => key.toLowerCase() === 'location');
 			const location: string | string[] | undefined = key && res.headers[key]
-			resolve(res.statusCode === 302 && typeof location === 'string' && location.startsWith('http://127.0.0.1:3333/callback'));
+			resolve(res.statusCode === 302 && typeof location === 'string' && location.startsWith(testCallbackUrl));
 		});
 		req.on('error', error => {
 			logErrorMessage(error);
@@ -190,9 +192,7 @@ async function callback(nonce: string, reqUrl: url.Url): Promise<string> {
 		code = getQueryProp(query, 'code');
 
 		if (!error) {
-			const state: string = getQueryProp(query, 'state');
-			const receivedNonce: string = (state?.split(',')[1] || '').replace(/ /g, '+');
-
+			const receivedNonce: string = getQueryProp(query, 'nonce').replace(/ /g, '+');
 			if (receivedNonce !== nonce) {
 				error = 'Nonce does not match.';
 			}


### PR DESCRIPTION
The VS Code team switched to using `https://vscode.dev/redirect` and will soon be deprecating the old redirect server (`https://vscode-redirect.azurewebsites.net/`). 

The old redirect server required a very specific `state` to perform redirects. If the state format wasn't matched, the server would return an error code.

The new redirect server's `state` is simply the URL we wish to redirect to. I still include the nonce in the redirect URL so we can check it upon receiving the auth code.