### PR TITLE
Add `updateSubscriptionsAndTenants/subscriptions` telemetry event

### DIFF
--- a/src/login/AzureLoginHelper.ts
+++ b/src/login/AzureLoginHelper.ts
@@ -62,7 +62,7 @@ export class AzureAccountLoginHelper {
 	constructor(public context: ExtensionContext, actionContext: IActionContext) {
 		this.adalAuthProvider = new AdalAuthProvider(enableVerboseLogs);
 		this.msalAuthProvider = new MsalAuthProvider(enableVerboseLogs);
-		this.authProvider = getAuthLibrary() === 'ADAL' ?  this.adalAuthProvider : this.msalAuthProvider;
+		this.authProvider = getAuthLibrary() === 'ADAL' ? this.adalAuthProvider : this.msalAuthProvider;
 
 		this.api = new AzureAccountExtensionApi(this);
 		this.legacyApi = new AzureAccountExtensionLegacyApi(this.api);
@@ -113,7 +113,7 @@ export class AzureAccountLoginHelper {
 			const environmentLabel: string = environmentLabels[environmentName] || localize('azure-account.unknownCloud', 'unknown cloud');
 
 			await window.withProgress({
-				title: localize('azure-account.signingIn', 'Signing in to {0}...', environmentLabel), 
+				title: localize('azure-account.signingIn', 'Signing in to {0}...', environmentLabel),
 				location: ProgressLocation.Notification,
 				cancellable: true
 			}, async (_progress, cancellationToken) => {
@@ -150,7 +150,7 @@ export class AzureAccountLoginHelper {
 					await this.authProvider.login(context, clientId, environment, isAdfs, tenantId, openUri, redirectTimeout, cancellationToken) :
 					await this.authProvider.loginWithDeviceCode(context, environment, tenantId, cancellationToken);
 				await this.updateSessions(this.authProvider, environment, loginResult);
-				void this.sendLoginTelemetry(context, { trigger, codePath, environmentName, outcome: 'success' }, true);
+				void this.sendLoginTelemetry(context, { trigger, codePath, environmentName, outcome: 'success' });
 			});
 		} catch (err) {
 			if (err instanceof AzureLoginError && err.reason) {
@@ -167,14 +167,10 @@ export class AzureAccountLoginHelper {
 		}
 	}
 
-	private async sendLoginTelemetry(context: IActionContext, properties: { trigger: LoginTrigger, codePath: CodePath, environmentName: string, outcome: string, message?: string }, includeSubscriptions?: boolean) {
+	private async sendLoginTelemetry(context: IActionContext, properties: { trigger: LoginTrigger, codePath: CodePath, environmentName: string, outcome: string, message?: string }) {
 		context.telemetry.properties = {
 			...context.telemetry.properties,
 			...properties
-		}
-		if (includeSubscriptions) {
-			await this.api.waitForSubscriptions();
-			context.telemetry.properties.subscriptions = JSON.stringify((this.api.subscriptions).map(s => s.subscription.subscriptionId));
 		}
 	}
 
@@ -200,7 +196,7 @@ export class AzureAccountLoginHelper {
 				this.beginLoggingIn();
 				const loginResult = await this.authProvider.loginSilent(environment, tenantId);
 				await this.updateSessions(this.authProvider, environment, loginResult);
-				void this.sendLoginTelemetry(context, { trigger, codePath, environmentName, outcome: 'success' }, true);
+				void this.sendLoginTelemetry(context, { trigger, codePath, environmentName, outcome: 'success' });
 			} catch (err) {
 				await this.clearSessions(); // clear out cached data
 				if (err instanceof AzureLoginError && err.reason) {

--- a/src/login/updateSubscriptions.ts
+++ b/src/login/updateSubscriptions.ts
@@ -22,6 +22,9 @@ export async function updateSubscriptionsAndTenants(): Promise<void> {
 		ext.loginHelper.api.subscriptions.splice(0, ext.loginHelper.api.subscriptions.length, ...await ext.loginHelper.subscriptionsTask);
 		ext.loginHelper.tenantsTask = loadTenants(context);
 
+		// This event is relied upon by the DevDiv Analytics and Growth Team
+		context.telemetry.properties.subscriptions = JSON.stringify((ext.loginHelper.api.subscriptions).map(s => s.subscription.subscriptionId));
+
 		if (ext.loginHelper.api.status !== 'LoggedIn') {
 			void ext.loginHelper.context.globalState.update(cacheKey, undefined);
 			return;
@@ -52,8 +55,8 @@ async function loadTenants(context: IActionContext): Promise<TenantIdDescription
 	for (const session of ext.loginHelper.api.sessions) {
 		const client: SubscriptionClient = new SubscriptionClient(session.credentials2, { baseUri: session.environment.resourceManagerEndpointUrl });
 		const environment = await getSelectedEnvironment();
-		const resourceManagerEndpointUrl: string = environment.resourceManagerEndpointUrl.endsWith('/') ? 
-			environment.resourceManagerEndpointUrl : 
+		const resourceManagerEndpointUrl: string = environment.resourceManagerEndpointUrl.endsWith('/') ?
+			environment.resourceManagerEndpointUrl :
 			`${environment.resourceManagerEndpointUrl}/`;
 		let url: string | undefined = `${resourceManagerEndpointUrl}tenants?api-version=2020-01-01`;
 


### PR DESCRIPTION
The DevDiv Analytics and Growth Team now relies on the `subscriptions` property of the `updateSubscriptionsAndTenants` event.

I'm removing the subscriptions property from `AzureLoginHelper` due to difficult to diagnose timing issues. It's much easier to put the property on `updateSubscriptionsAndTenants` and that satisfies the needs of the partner team.

Apologies for the random whitespace changes. I had my auto-formatter turned off.