### PR TITLE
Revert removal of `prompt` property in query string.

### DIFF
--- a/src/login/AuthProviderBase.ts
+++ b/src/login/AuthProviderBase.ts
@@ -89,7 +89,7 @@ export abstract class AuthProviderBase<TLoginResult> {
 			const updatedPort: number = updatedPortStr ? parseInt(updatedPortStr, 10) : port;
 			const state: string = `${encodeURIComponent(getLocalCallbackUrl(updatedPort))}?nonce=${encodeURIComponent(nonce)}`;
 			const redirectUrl: string = isAdfs ? redirectUrlADFS : redirectUrlAAD;
-			const signInUrl: string = `${environment.activeDirectoryEndpointUrl}${isAdfs ? '' : `${tenantId}/`}oauth2/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUrl)}&state=${state}`;
+			const signInUrl: string = `${environment.activeDirectoryEndpointUrl}${isAdfs ? '' : `${tenantId}/`}oauth2/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUrl)}&state=${state}&prompt=select_account`;
 
 			logAttemptingToReachUrlMessage(redirectUrl);
 			logAttemptingToReachUrlMessage(signInUrl);
@@ -135,7 +135,7 @@ export abstract class AuthProviderBase<TLoginResult> {
 		logAttemptingToReachUrlMessage(signInUrl);
 		let uri: Uri = Uri.parse(signInUrl);
 		uri = uri.with({
-			query: `response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${redirectUrlAAD}&state=${state}`
+			query: `response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${redirectUrlAAD}&state=${state}&prompt=select_account`
 		});
 		void env.openExternal(uri);
 


### PR DESCRIPTION
A prior change to use the new VS Code redirect server eliminated the `prompt` property of the login query string, which tells the service to allow the user to select the account in the browser (from the list of currently-logged-in accounts).  However, this is likely the desired behavior, so this change reverts that removal.

> The `prompt` property only seems to have had an impact on Windows; Mac seemed to prompt regardless.

Resolves #594.