### PR TITLE
Don't prompt to sign out and reload on first run

### DIFF
--- a/src/login/checkSettingsOnStartup.ts
+++ b/src/login/checkSettingsOnStartup.ts
@@ -41,7 +41,6 @@ export async function checkSettingsOnStartup(extensionContext: ExtensionContext,
 
     await extensionContext.globalState.update(settingsCacheKey, lastSeenSettingsCacheNew);
 
-    actionContext.telemetry.properties.shouldSignOutAndReload = String(shouldSignOutAndReload);
     if (shouldSignOutAndReload) {
         await askThenSignOutAndReload(actionContext, loginHelper);
     }


### PR DESCRIPTION
The first time the Account extension runs on an installation of VS Code, the settings cache we keep is undefined. The current logic sees that undefined is different from the current settings values (defaults) and we prompt the user to sign in a reload (before they have even signed in).

Edit: found this bug when trying to fix the tests