### PR TITLE
Only add electron run as node when in electron

### DIFF
--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -283,7 +283,7 @@ export function createCloudConsole(api: AzureAccountExtensionApi, osName: OSName
 				shellArgs.shift();
 			}
 
-			if (!isWindows && env.uiKind === UIKind.Desktop && semver.gte(version, '1.62.1')) {
+			if (!isWindows && !!process.versions['electron'] && env.uiKind === UIKind.Desktop && semver.gte(version, '1.62.1')) {
 				// https://github.com/microsoft/vscode/issues/136987
 				// This fix can't be applied to all versions of VS Code. An error is thrown in versions less than the one specified
 				shellArgs.push('--ms-enable-electron-run-as-node');

--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -283,6 +283,7 @@ export function createCloudConsole(api: AzureAccountExtensionApi, osName: OSName
 				shellArgs.shift();
 			}
 
+			// Only add flag if in Electron process https://github.com/microsoft/vscode-azure-account/pull/684
 			if (!isWindows && !!process.versions['electron'] && env.uiKind === UIKind.Desktop && semver.gte(version, '1.62.1')) {
 				// https://github.com/microsoft/vscode/issues/136987
 				// This fix can't be applied to all versions of VS Code. An error is thrown in versions less than the one specified


### PR DESCRIPTION
Fixes #682, #601 

This fixes connecting to Cloud Shell while connected to _something_ (WSL, CodeSpaces, Dev Container, etc.) from VS Code desktop.

This flag should only be used when executing Node from an Electron process. However, many scenarios of VS Code are not Electron processes anymore, and are just plain Node processes.

We had covered most cases by checking if UiKind === Desktop, however cases like connecting to Codespaces from VS Code Desktop were not covered.

To fix this, we can check if the current process is Electron by checking if `process.versions['electron']` is defined.

Related PRs:
https://github.com/microsoft/vscode-azure-account/pull/432 
https://github.com/microsoft/vscode-azure-account/pull/357

https://github.com/microsoft/vscode/issues/136987