### PR TITLE
Force adal-node to use Axios 1.2.0 for proxy support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-account",
-    "version": "0.11.4-alpha.0",
+    "version": "0.11.4-alpha.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-account",
-            "version": "0.11.4-alpha.0",
+            "version": "0.11.4-alpha.2",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-resources": "^4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-account",
-    "version": "0.11.4-alpha.2",
+    "version": "0.11.4-alpha.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-account",
-            "version": "0.11.4-alpha.2",
+            "version": "0.11.4-alpha.1",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-resources": "^4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13133,7 +13133,7 @@
             "requires": {
                 "@xmldom/xmldom": "^0.7.0",
                 "async": "^2.6.3",
-                "axios": "^0.21.1",
+                "axios": "1.2.0",
                 "date-utils": "*",
                 "jws": "3.x.x",
                 "underscore": ">= 1.3.1",
@@ -13500,8 +13500,7 @@
             "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
         },
         "axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "version": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
             "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
             "requires": {
                 "follow-redirects": "^1.14.0"

--- a/package.json
+++ b/package.json
@@ -324,5 +324,10 @@
         "uuid": "^8.3.2",
         "vscode-nls": "4.0.0",
         "ws": "^8.9.0"
+    },
+    "overrides": {
+        "adal-node": {
+            "axios": "1.2.0"
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "color": "#0072c6",
         "theme": "dark"
     },
-    "version": "0.11.4-alpha.0",
+    "version": "0.11.4-alpha.2",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-vscode",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "color": "#0072c6",
         "theme": "dark"
     },
-    "version": "0.11.4-alpha.2",
+    "version": "0.11.4-alpha.1",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-vscode",
     "engines": {


### PR DESCRIPTION
This updated version of Axios includes some fixes for proxy support.

I'll be opening some other PRs with possible other possible fixes.

Old version: 0.21.4
New version: 1.2.0