### PR TITLE
Add detailed logging 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@azure/ms-rest-js": "^2.6.0",
                 "@azure/ms-rest-nodeauth": "^3.0.10",
                 "@azure/msal-node": "^1.14.6",
-                "@microsoft/vscode-azext-utils": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.5.1.tgz",
+                "@microsoft/vscode-azext-utils": "^1.0.0",
                 "adal-node": "^0.2.3",
                 "form-data": "2.3.3",
                 "http-proxy-agent": "^5.0.0",
@@ -496,20 +496,20 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.5.1",
-            "resolved": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.5.1.tgz",
-            "integrity": "sha512-6bLzJV9jYUeYAONE3bAQ3QeSnyjyqOlnlT5g6+tWvwL4YBOscXGKkLIu1sHhxYig/eBd+R+XcRGfZfGWH4K8cg==",
-            "license": "MIT",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-1.0.0.tgz",
+            "integrity": "sha512-5j7rlCUMcTF0cKHLC5eeo3JT7T/X1Ex25i9nqUGRe6hgDgvuHrS5icpta6KyqZswtCK0RIU1mGQrD7UfwHJN1g==",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.2",
                 "@vscode/extension-telemetry": "^0.6.2",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^8.2.0",
-                "open": "^8.0.4",
                 "semver": "^7.3.7",
+                "uuid": "^9.0.0",
                 "vscode-nls": "^5.0.1",
-                "vscode-tas-client": "^0.1.47"
+                "vscode-tas-client": "^0.1.47",
+                "vscode-uri": "^3.0.6"
             }
         },
         "node_modules/@microsoft/vscode-azext-utils/node_modules/semver": {
@@ -524,6 +524,14 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/@microsoft/vscode-azext-utils/node_modules/uuid": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@microsoft/vscode-azext-utils/node_modules/vscode-nls": {
@@ -2953,14 +2961,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/define-properties": {
@@ -5859,20 +5859,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-extendable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
@@ -6140,17 +6126,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "dependencies": {
-                "is-docker": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/isarray": {
@@ -7636,22 +7611,6 @@
             },
             "engines": {
                 "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/open": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
-            "dependencies": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -11492,6 +11451,11 @@
                 "vscode": "^1.19.1"
             }
         },
+        "node_modules/vscode-uri": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
+            "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
+        },
         "node_modules/watchpack": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -12401,18 +12365,20 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.5.1.tgz",
-            "integrity": "sha512-6bLzJV9jYUeYAONE3bAQ3QeSnyjyqOlnlT5g6+tWvwL4YBOscXGKkLIu1sHhxYig/eBd+R+XcRGfZfGWH4K8cg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-1.0.0.tgz",
+            "integrity": "sha512-5j7rlCUMcTF0cKHLC5eeo3JT7T/X1Ex25i9nqUGRe6hgDgvuHrS5icpta6KyqZswtCK0RIU1mGQrD7UfwHJN1g==",
             "requires": {
                 "@microsoft/vscode-azureresources-api": "^2.0.2",
                 "@vscode/extension-telemetry": "^0.6.2",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
                 "html-to-text": "^8.2.0",
-                "open": "^8.0.4",
                 "semver": "^7.3.7",
+                "uuid": "^9.0.0",
                 "vscode-nls": "^5.0.1",
-                "vscode-tas-client": "^0.1.47"
+                "vscode-tas-client": "^0.1.47",
+                "vscode-uri": "^3.0.6"
             },
             "dependencies": {
                 "semver": {
@@ -12422,6 +12388,11 @@
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
+                },
+                "uuid": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+                    "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
                 },
                 "vscode-nls": {
                     "version": "5.0.1",
@@ -14351,11 +14322,6 @@
             "resolved": "https://registry.npmjs.org/default-resolution/-/default-resolution-2.0.0.tgz",
             "integrity": "sha1-vLgrqnKtebQmp2cy8aga1t8m1oQ=",
             "dev": true
-        },
-        "define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
         },
         "define-properties": {
             "version": "1.1.3",
@@ -16623,11 +16589,6 @@
                 }
             }
         },
-        "is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
-        },
         "is-extendable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
@@ -16814,14 +16775,6 @@
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
-        },
-        "is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-            "requires": {
-                "is-docker": "^2.0.0"
-            }
         },
         "isarray": {
             "version": "1.0.0",
@@ -18005,16 +17958,6 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
-            }
-        },
-        "open": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-            "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
-            "requires": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
             }
         },
         "optionator": {
@@ -21055,6 +20998,11 @@
             "requires": {
                 "tas-client": "0.1.45"
             }
+        },
+        "vscode-uri": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
+            "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
         },
         "watchpack": {
             "version": "2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@azure/ms-rest-js": "^2.6.0",
                 "@azure/ms-rest-nodeauth": "^3.0.10",
                 "@azure/msal-node": "^1.14.6",
-                "@microsoft/vscode-azext-utils": "^0.3.7",
+                "@microsoft/vscode-azext-utils": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.5.1.tgz",
                 "adal-node": "^0.2.3",
                 "form-data": "2.3.3",
                 "http-proxy-agent": "^5.0.0",
@@ -41,7 +41,7 @@
                 "@types/request-promise": "4.1.42",
                 "@types/semver": "5.5.0",
                 "@types/uuid": "^8.3.0",
-                "@types/vscode": "1.65.0",
+                "@types/vscode": "^1.74.0",
                 "@types/ws": "^8.5.3",
                 "@typescript-eslint/eslint-plugin": "^4.14.2",
                 "copy-webpack-plugin": "^6.0.0",
@@ -60,7 +60,7 @@
                 "webpack-cli": "^4.5.0"
             },
             "engines": {
-                "vscode": "^1.65.0"
+                "vscode": "^1.74.0"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -496,10 +496,12 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.7.tgz",
-            "integrity": "sha512-TCIo1rVPYso5r9UrDfZK2j9FvvruW4BOTjtgK9g8F6gRB3FvpBd8AlQhXcffe8NmKNPJhbmdRSwhk51EujK2FA==",
+            "version": "0.5.1",
+            "resolved": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.5.1.tgz",
+            "integrity": "sha512-6bLzJV9jYUeYAONE3bAQ3QeSnyjyqOlnlT5g6+tWvwL4YBOscXGKkLIu1sHhxYig/eBd+R+XcRGfZfGWH4K8cg==",
+            "license": "MIT",
             "dependencies": {
+                "@microsoft/vscode-azureresources-api": "^2.0.2",
                 "@vscode/extension-telemetry": "^0.6.2",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
@@ -528,6 +530,11 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.1.tgz",
             "integrity": "sha512-hHQV6iig+M21lTdItKPkJAaWrxALQb/nqpVffakO4knJOh3DrU2SXOMzUzNgo1eADPzu3qSsJY1weCzvR52q9A=="
+        },
+        "node_modules/@microsoft/vscode-azureresources-api": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-2.0.3.tgz",
+            "integrity": "sha512-F//P8rdlTQPXcZu3ycpHasOg8BJXB5YQyVcJgbq84R0FTn0fHeHl8MdCui1S/jP96P7yZYMzDWnIu/nk3magHA=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -887,9 +894,9 @@
             }
         },
         "node_modules/@types/vscode": {
-            "version": "1.65.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
-            "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
+            "version": "1.74.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+            "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
             "dev": true
         },
         "node_modules/@types/webpack": {
@@ -12394,10 +12401,10 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.7.tgz",
-            "integrity": "sha512-TCIo1rVPYso5r9UrDfZK2j9FvvruW4BOTjtgK9g8F6gRB3FvpBd8AlQhXcffe8NmKNPJhbmdRSwhk51EujK2FA==",
+            "version": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.5.1.tgz",
+            "integrity": "sha512-6bLzJV9jYUeYAONE3bAQ3QeSnyjyqOlnlT5g6+tWvwL4YBOscXGKkLIu1sHhxYig/eBd+R+XcRGfZfGWH4K8cg==",
             "requires": {
+                "@microsoft/vscode-azureresources-api": "^2.0.2",
                 "@vscode/extension-telemetry": "^0.6.2",
                 "dayjs": "^1.11.2",
                 "escape-string-regexp": "^2.0.0",
@@ -12422,6 +12429,11 @@
                     "integrity": "sha512-hHQV6iig+M21lTdItKPkJAaWrxALQb/nqpVffakO4knJOh3DrU2SXOMzUzNgo1eADPzu3qSsJY1weCzvR52q9A=="
                 }
             }
+        },
+        "@microsoft/vscode-azureresources-api": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-2.0.3.tgz",
+            "integrity": "sha512-F//P8rdlTQPXcZu3ycpHasOg8BJXB5YQyVcJgbq84R0FTn0fHeHl8MdCui1S/jP96P7yZYMzDWnIu/nk3magHA=="
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -12758,9 +12770,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.65.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
-            "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
+            "version": "1.74.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+            "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
             "dev": true
         },
         "@types/webpack": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "publisher": "ms-vscode",
     "engines": {
-        "vscode": "^1.65.0"
+        "vscode": "^1.74.0"
     },
     "categories": [
         "Azure"
@@ -285,7 +285,7 @@
         "@types/request-promise": "4.1.42",
         "@types/semver": "5.5.0",
         "@types/uuid": "^8.3.0",
-        "@types/vscode": "1.65.0",
+        "@types/vscode": "^1.74.0",
         "@types/ws": "^8.5.3",
         "@typescript-eslint/eslint-plugin": "^4.14.2",
         "copy-webpack-plugin": "^6.0.0",
@@ -311,7 +311,7 @@
         "@azure/ms-rest-js": "^2.6.0",
         "@azure/ms-rest-nodeauth": "^3.0.10",
         "@azure/msal-node": "^1.14.6",
-        "@microsoft/vscode-azext-utils": "^0.3.7",
+        "@microsoft/vscode-azext-utils": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.5.1.tgz",
         "adal-node": "^0.2.3",
         "form-data": "2.3.3",
         "http-proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -311,7 +311,7 @@
         "@azure/ms-rest-js": "^2.6.0",
         "@azure/ms-rest-nodeauth": "^3.0.10",
         "@azure/msal-node": "^1.14.6",
-        "@microsoft/vscode-azext-utils": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.5.1.tgz",
+        "@microsoft/vscode-azext-utils": "^1.0.0",
         "adal-node": "^0.2.3",
         "form-data": "2.3.3",
         "http-proxy-agent": "^5.0.0",

--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -10,7 +10,7 @@ import { ReadStream } from 'fs';
 import { ClientRequest } from 'http';
 import { DeviceTokenCredentials } from 'ms-rest-azure';
 import { Socket } from 'net';
-import fetch, { Response } from 'node-fetch';
+import { Response } from 'node-fetch';
 import * as path from 'path';
 import * as semver from 'semver';
 import { parse, UrlWithStringQuery } from 'url';
@@ -24,6 +24,7 @@ import { tokenFromRefreshToken } from '../login/adal/tokens';
 import { getAuthLibrary } from '../login/getAuthLibrary';
 import { localize } from '../utils/localize';
 import { logErrorMessage } from '../utils/logErrorMessage';
+import { fetchWithLogging } from '../utils/logging/nodeFetch/nodeFetch';
 import { Deferred } from '../utils/promiseUtils';
 import { AccessTokens, connectTerminal, ConsoleUris, Errors, getUserSettings, provisionConsole, resetConsole, Size, UserSettings } from './cloudConsoleLauncher';
 import { CloudShellInternal } from './CloudShellInternal';
@@ -602,7 +603,7 @@ async function fetchTenantDetails(session: AzureSession): Promise<{ session: Azu
 
 			if (result) {
 				try {
-					const response: Response = await fetch(requestUrl, {
+					const response: Response = await fetchWithLogging(requestUrl, {
 						headers: {
 							// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 							Authorization: `Bearer ${result.accessToken}`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { callWithTelemetryAndErrorHandling, createApiProvider, createAzExtOutputChannel, createExperimentationService, IActionContext, registerCommand, registerReportIssueCommand, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
-import { AzureExtensionApiProvider } from '@microsoft/vscode-azext-utils/api';
+import { apiUtils, callWithTelemetryAndErrorHandling, createApiProvider, createAzExtLogOutputChannel, createExperimentationService, IActionContext, registerCommand, registerReportIssueCommand, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
 import { createReadStream } from 'fs';
 import { basename } from 'path';
 import { CancellationToken, ConfigurationTarget, env, ExtensionContext, ProgressLocation, Uri, window, workspace, WorkspaceConfiguration } from 'vscode';
@@ -28,9 +27,9 @@ import { getSettingValue } from './utils/settingUtils';
 
 const enableLogging: boolean = false;
 
-export async function activateInternal(context: ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }): Promise<AzureExtensionApiProvider> {
+export async function activateInternal(context: ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }): Promise<apiUtils.AzureExtensionApiProvider> {
 	ext.context = context;
-	ext.outputChannel = createAzExtOutputChannel(displayName, extensionPrefix);
+	ext.outputChannel = createAzExtLogOutputChannel(displayName);
 	ext.uriEventHandler = new UriEventHandler();
 	context.subscriptions.push(ext.outputChannel);
 	context.subscriptions.push(window.registerUriHandler(ext.uriEventHandler));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,12 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { apiUtils, callWithTelemetryAndErrorHandling, createApiProvider, createAzExtLogOutputChannel, createExperimentationService, IActionContext, registerCommand, registerReportIssueCommand, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
+import { IActionContext, apiUtils, callWithTelemetryAndErrorHandling, createApiProvider, createAzExtLogOutputChannel, createExperimentationService, registerCommand, registerReportIssueCommand, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
+import axios from 'axios';
 import { createReadStream } from 'fs';
 import { basename } from 'path';
-import { CancellationToken, ConfigurationTarget, env, ExtensionContext, ProgressLocation, Uri, window, workspace, WorkspaceConfiguration } from 'vscode';
+import { CancellationToken, ConfigurationTarget, ExtensionContext, ProgressLocation, Uri, WorkspaceConfiguration, env, window, workspace } from 'vscode';
 import { AzureAccountExtensionApi } from './azure-account.api';
-import { createCloudConsole, OSes, OSName, shells } from './cloudConsole/cloudConsole';
+import { OSName, OSes, createCloudConsole, shells } from './cloudConsole/cloudConsole';
 import { cloudSetting, displayName, extensionPrefix, showSignedInEmailSetting } from './constants';
 import { ext } from './extensionVariables';
 import { AzureAccountLoginHelper } from './login/AzureAccountLoginHelper';
@@ -23,6 +24,7 @@ import { updateSubscriptionsAndTenants } from './login/updateSubscriptions';
 import { survey } from './nps';
 import { localize } from './utils/localize';
 import { logErrorMessage } from './utils/logErrorMessage';
+import { setupAxiosLogging } from './utils/logging/axios/AxiosNormalizer';
 import { getSettingValue } from './utils/settingUtils';
 
 const enableLogging: boolean = false;
@@ -34,6 +36,7 @@ export async function activateInternal(context: ExtensionContext, perfStats: { l
 	context.subscriptions.push(ext.outputChannel);
 	context.subscriptions.push(window.registerUriHandler(ext.uriEventHandler));
 	registerUIExtensionVariables(ext);
+	setupAxiosLogging(axios, ext.outputChannel);
 
 	await callWithTelemetryAndErrorHandling('azure-account.activate', async (activateContext: IActionContext) => {
 		activateContext.telemetry.properties.isActivationEvent = 'true';

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzExtOutputChannel, IExperimentationServiceAdapter } from "@microsoft/vscode-azext-utils";
+import { IAzExtLogOutputChannel, IExperimentationServiceAdapter } from "@microsoft/vscode-azext-utils";
 import { ExtensionContext } from "vscode";
 import { AzureAccountLoginHelper } from "./login/AzureAccountLoginHelper";
 import { UriEventHandler } from "./login/exchangeCodeForToken";
@@ -11,7 +11,7 @@ import { UriEventHandler } from "./login/exchangeCodeForToken";
 export namespace ext {
     export let context: ExtensionContext;
     export let loginHelper: AzureAccountLoginHelper;
-    export let outputChannel: IAzExtOutputChannel;
+    export let outputChannel: IAzExtLogOutputChannel;
     export let uriEventHandler: UriEventHandler;
     export let experimentationService: IExperimentationServiceAdapter;
 }

--- a/src/login/AuthProviderBase.ts
+++ b/src/login/AuthProviderBase.ts
@@ -10,7 +10,7 @@ import { IActionContext, parseError } from "@microsoft/vscode-azext-utils";
 import { randomBytes } from "crypto";
 import { ServerResponse } from "http";
 import { DeviceTokenCredentials } from "ms-rest-azure";
-import { CancellationToken, MessageItem, UIKind, Uri, env, window } from "vscode";
+import { CancellationToken, env, MessageItem, UIKind, Uri, window } from "vscode";
 import { AzureAccountExtensionApi, AzureSession } from "../azure-account.api";
 import { portADFS, redirectUrlAAD } from "../constants";
 import { ext } from "../extensionVariables";
@@ -18,13 +18,13 @@ import { logAttemptingToReachUrlMessage } from "../logAttemptingToReachUrlMessag
 import { localize } from "../utils/localize";
 import { logErrorMessage } from "../utils/logErrorMessage";
 import { openUri } from "../utils/openUri";
-import { AzureSessionInternal } from "./AzureSessionInternal";
 import { DeviceTokenCredentials2 } from "./adal/DeviceTokenCredentials2";
+import { AzureSessionInternal } from "./AzureSessionInternal";
 import { getEnvironments } from "./environments";
 import { exchangeCodeForToken } from "./exchangeCodeForToken";
 import { getLocalCallbackUrl } from "./getCallbackUrl";
 import { getKey } from "./getKey";
-import { CodeResult, RedirectResult, createServer, createTerminateServer, startServer } from './server';
+import { CodeResult, createServer, createTerminateServer, RedirectResult, startServer } from './server';
 import { SubscriptionTenantCache } from "./subscriptionTypes";
 
 export type AbstractCredentials = DeviceTokenCredentials;

--- a/src/login/AuthProviderBase.ts
+++ b/src/login/AuthProviderBase.ts
@@ -10,7 +10,7 @@ import { IActionContext, parseError } from "@microsoft/vscode-azext-utils";
 import { randomBytes } from "crypto";
 import { ServerResponse } from "http";
 import { DeviceTokenCredentials } from "ms-rest-azure";
-import { CancellationToken, env, MessageItem, UIKind, Uri, window } from "vscode";
+import { CancellationToken, MessageItem, UIKind, Uri, env, window } from "vscode";
 import { AzureAccountExtensionApi, AzureSession } from "../azure-account.api";
 import { portADFS, redirectUrlAAD } from "../constants";
 import { ext } from "../extensionVariables";
@@ -18,13 +18,13 @@ import { logAttemptingToReachUrlMessage } from "../logAttemptingToReachUrlMessag
 import { localize } from "../utils/localize";
 import { logErrorMessage } from "../utils/logErrorMessage";
 import { openUri } from "../utils/openUri";
-import { DeviceTokenCredentials2 } from "./adal/DeviceTokenCredentials2";
 import { AzureSessionInternal } from "./AzureSessionInternal";
+import { DeviceTokenCredentials2 } from "./adal/DeviceTokenCredentials2";
 import { getEnvironments } from "./environments";
 import { exchangeCodeForToken } from "./exchangeCodeForToken";
 import { getLocalCallbackUrl } from "./getCallbackUrl";
 import { getKey } from "./getKey";
-import { CodeResult, createServer, createTerminateServer, RedirectResult, startServer } from './server';
+import { CodeResult, RedirectResult, createServer, createTerminateServer, startServer } from './server';
 import { SubscriptionTenantCache } from "./subscriptionTypes";
 
 export type AbstractCredentials = DeviceTokenCredentials;

--- a/src/login/AzureAccountLoginHelper.ts
+++ b/src/login/AzureAccountLoginHelper.ts
@@ -32,8 +32,6 @@ import { TenantIdDescription } from './TenantIdDescription';
 import { updateFilters } from './updateFilters';
 import { waitUntilOnline } from './waitUntilOnline';
 
-const enableVerboseLogs: boolean = false;
-
 interface IAzureAccountWriteable extends AzureAccountExtensionApi {
 	status: AzureLoginStatus;
 }
@@ -60,8 +58,8 @@ export class AzureAccountLoginHelper {
 	public legacyApi: AzureAccountExtensionLegacyApi;
 
 	constructor(public context: ExtensionContext, actionContext: IActionContext) {
-		this.adalAuthProvider = new AdalAuthProvider(enableVerboseLogs);
-		this.msalAuthProvider = new MsalAuthProvider(enableVerboseLogs);
+		this.adalAuthProvider = new AdalAuthProvider();
+		this.msalAuthProvider = new MsalAuthProvider();
 		this.authProvider = getAuthLibrary() === 'ADAL' ? this.adalAuthProvider : this.msalAuthProvider;
 
 		this.api = new AzureAccountExtensionApi(this);

--- a/src/login/adal/AdalAuthProvider.ts
+++ b/src/login/adal/AdalAuthProvider.ts
@@ -41,6 +41,9 @@ export class AdalAuthProvider extends AuthProviderBase<TokenResponse[]> {
 		Logging.setLoggingOptions({
 			level: ADALLogLevel.Verbose,
 			log: (level: LoggingLevel, message: string, error?: Error) => {
+				// example message:
+				// Wed, 22 Mar 2023 20:03:04 GMT:c118cca5-90ce-4fcb-b3ed-e73d32fc1eee - TokenRequest: INFO: Getting a new token from a refresh token.
+				message = message.replace(/.*-\s/, ''); // remove ADAL log timestamp and id
 				message = 'ADAL: ' + message;
 				switch (level) {
 					case ADALLogLevel.Error:
@@ -50,10 +53,10 @@ export class AdalAuthProvider extends AuthProviderBase<TokenResponse[]> {
 						ext.outputChannel.warn(message);
 						break;
 					case ADALLogLevel.Info:
-						ext.outputChannel.info(message);
+						ext.outputChannel.debug(message);
 						break;
 					case ADALLogLevel.Verbose:
-						ext.outputChannel.debug(message);
+						ext.outputChannel.trace(message);
 				}
 			}
 		});

--- a/src/login/environments.ts
+++ b/src/login/environments.ts
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Environment } from "@azure/ms-rest-azure-env";
-import fetch, { Response } from "node-fetch";
+import { Response } from "node-fetch";
 import * as url from 'url';
 import { commands, window, workspace, WorkspaceConfiguration } from "vscode";
 import { azureCustomCloud, azurePPE, cloudSetting, customCloudArmUrlSetting, extensionPrefix, ppeSetting, staticEnvironments } from "../constants";
 import { localize } from "../utils/localize";
+import { fetchWithLogging } from "../utils/logging/nodeFetch/nodeFetch";
 import { getSettingValue } from "../utils/settingUtils";
 
 interface ICloudMetadata {
@@ -56,7 +57,7 @@ export async function getEnvironments(includePartial: boolean = false): Promise<
 	const metadataDiscoveryUrl: string | undefined = process.env['ARM_CLOUD_METADATA_URL'];
 	if (metadataDiscoveryUrl) {
 		try {
-			const response: Response = await fetch(metadataDiscoveryUrl);
+			const response: Response = await fetchWithLogging(metadataDiscoveryUrl);
 			if (response.ok) {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 				const endpoints: ICloudMetadata[] = await response.json();
@@ -114,7 +115,7 @@ async function getCustomCloudEnvironment(config: WorkspaceConfiguration, include
 	if (armUrl) {
 		try {
 			const endpointsUrl: string = getMetadataEndpoints(armUrl);
-			const endpointsResponse: Response = await fetch(endpointsUrl);
+			const endpointsResponse: Response = await fetchWithLogging(endpointsUrl);
 			if (endpointsResponse.ok) {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 				const endpoints: IResourceManagerMetadata = await endpointsResponse.json();

--- a/src/login/msal/MsalAuthProvider.ts
+++ b/src/login/msal/MsalAuthProvider.ts
@@ -34,14 +34,14 @@ export class MsalAuthProvider extends AuthProviderBase<AuthenticationResult> {
 					loggerCallback: (_level: LogLevel, message: string, _containsPii: boolean) => {
 						message = 'MSAL: ' + message;
 						switch (_level) {
-							case LogLevel.Info:
-								ext.outputChannel.info(message);
+							case LogLevel.Error:
+								ext.outputChannel.error(message);
 								break;
 							case LogLevel.Warning:
 								ext.outputChannel.warn(message);
 								break;
-							case LogLevel.Error:
-								ext.outputChannel.error(message);
+							case LogLevel.Info:
+								ext.outputChannel.info(message);
 								break;
 							case LogLevel.Verbose:
 								ext.outputChannel.debug(message);
@@ -51,7 +51,7 @@ export class MsalAuthProvider extends AuthProviderBase<AuthenticationResult> {
 								break;
 						}
 					},
-					piiLoggingEnabled: false,
+					piiLoggingEnabled: true,
 					logLevel: LogLevel.Trace,
 				}
 			}

--- a/src/utils/logErrorMessage.ts
+++ b/src/utils/logErrorMessage.ts
@@ -8,5 +8,5 @@ import { ext } from "../extensionVariables";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export function logErrorMessage(error: any): void {
-	ext.outputChannel.appendLog(parseError(error).message);
+	ext.outputChannel.error(parseError(error).message);
 }

--- a/src/utils/logging/HttpLogger.ts
+++ b/src/utils/logging/HttpLogger.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { parseError } from "@microsoft/vscode-azext-utils";
+import { LogLevel, LogOutputChannel } from "vscode";
+import { DebugHttpStringifier, HttpStringifier, SimpleHttpStringifier, TraceHttpStringifier } from "./stringifyHttp";
+
+/**
+ * A normalized HTTP request for logging.
+ */
+export interface NormalizedHttpRequest {
+    method?: string;
+    url?: string;
+    headers?: Record<string, unknown>;
+    proxy?: {
+        host?: string;
+        port?: string;
+        protocol?: string;
+        password?: string;
+        username?: string;
+    };
+    query?: Record<string, string>;
+}
+
+/**
+ * A normalized HTTP response for logging.
+ */
+export interface NormalizedHttpResponse {
+    status?: number;
+    bodyAsText?: string;
+    headers?: Record<string, unknown>;
+    request: NormalizedHttpRequest;
+}
+
+export interface HttpNormalizer<TRequest, TResponse> {
+    normalizeRequest(request: TRequest): NormalizedHttpRequest;
+    normalizeResponse(response: TResponse): NormalizedHttpResponse;
+}
+
+export class HttpLogger<TRequest, TResponse> implements HttpLogger<TRequest, TResponse> {
+    constructor(private readonly logOutputChannel: LogOutputChannel, private readonly source: string, private readonly normalizer: HttpNormalizer<TRequest, TResponse>) {}
+
+    logRequest(request: TRequest): void {
+        try {
+            this.logNormalizedRequest(this.normalizer.normalizeRequest(request));
+        } catch (e) {
+            const error = parseError(e);
+            this.logOutputChannel.error('Error logging request: ' + error.message);
+        }
+    }
+
+    logResponse(response: TResponse): void {
+        try {
+            this.logNormalizedResponse(this.normalizer.normalizeResponse(response));
+        } catch (e) {
+            const error = parseError(e);
+            this.logOutputChannel.error('Error logging response: ' + error.message);
+        }
+    }
+
+    private logNormalizedRequest(request: NormalizedHttpRequest): void {
+        if (request.proxy) {
+            // if proxy is configured, always log proxy configuration
+            this.logOutputChannel.info(new DebugHttpStringifier().stringifyRequest(request, this.source));
+        } else {
+            this.logOutputChannel.info(this.getStringifier().stringifyRequest(request, this.source));
+        }
+    }
+
+    private logNormalizedResponse(response: NormalizedHttpResponse): void {
+        this.logOutputChannel.info(this.getStringifier().stringifyResponse(response, this.source));
+    }
+
+    getStringifier(): HttpStringifier {
+        switch(this.logOutputChannel.logLevel) {
+            case LogLevel.Debug:
+                return new DebugHttpStringifier();
+            case LogLevel.Trace:
+                return new TraceHttpStringifier();
+            default:
+                return new SimpleHttpStringifier();
+        }
+    }
+}

--- a/src/utils/logging/axios/AxiosNormalizer.ts
+++ b/src/utils/logging/axios/AxiosNormalizer.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { AxiosRequestConfig, AxiosResponse, AxiosStatic } from 'axios';
+import { LogOutputChannel } from "vscode";
+import { HttpLogger, HttpNormalizer, NormalizedHttpRequest, NormalizedHttpResponse } from "../HttpLogger";
+
+export class AxiosNormalizer implements HttpNormalizer<AxiosRequestConfig, AxiosResponse> {
+    normalizeRequest(request: AxiosRequestConfig): NormalizedHttpRequest {
+        const query = new URLSearchParams(request.data as string);
+        const queryParams = Array.from(query.entries());
+        const rec: Record<string, string> = {};
+        queryParams.forEach(([name, value]) => rec[name] = value);
+    
+        const sanitizedHeaders: Record<string, string> = {};
+        Object.entries(request.headers).forEach(([key, value]) => {
+            if (typeof value !== 'object') {
+                sanitizedHeaders[key] = String(value);
+            }
+        });
+    
+        return {
+            url: request.url,
+            method: request.method?.toUpperCase(),
+            headers: sanitizedHeaders,
+            query: rec,
+            proxy: request.proxy ? {
+                host: request.proxy.host,
+                port: String(request.proxy.port),
+                protocol: request.proxy.protocol,
+                password: request.proxy.auth?.password,
+                username: request.proxy.auth?.username,
+            } : undefined,
+        };
+    }
+
+    normalizeResponse(response: AxiosResponse): NormalizedHttpResponse {
+        return {
+            headers: response.headers as Record<string, string>,
+            request: this.normalizeRequest(response.config),
+            bodyAsText: JSON.stringify(response.data),
+            status: response.status,
+        };
+    }
+}
+
+export function setupAxiosLogging(axios: AxiosStatic, logOutputChannel: LogOutputChannel): void {
+    const axiosLogger = new HttpLogger(logOutputChannel, 'Axios', new AxiosNormalizer());
+
+    axios.interceptors.request.use((requestConfig) => {
+        axiosLogger.logRequest(requestConfig);
+        return requestConfig;
+    });
+    
+    axios.interceptors.response.use((response) => {
+        axiosLogger.logResponse(response);
+        return response;
+    });
+}

--- a/src/utils/logging/msRest/LogRequestPolicy.ts
+++ b/src/utils/logging/msRest/LogRequestPolicy.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { BaseRequestPolicy, HttpOperationResponse, RequestPolicy, RequestPolicyOptionsLike, WebResourceLike } from "@azure/ms-rest-js";
+import { LogOutputChannel } from "vscode";
+import { HttpLogger } from "../HttpLogger";
+import { MsRestNormalizer } from "./MsRestNormalizer";
+
+export class LogRequestPolicy extends BaseRequestPolicy {
+    private readonly logger: HttpLogger<WebResourceLike, HttpOperationResponse>;
+
+	constructor(outputChannel: LogOutputChannel, clientName: string, nextPolicy: RequestPolicy, options: RequestPolicyOptionsLike) {
+		super(nextPolicy, options);
+        this.logger = new HttpLogger(outputChannel, clientName, new MsRestNormalizer());
+	}
+
+	sendRequest(webResource: WebResourceLike): Promise<HttpOperationResponse> {
+		this.logger.logRequest(webResource);
+		
+        const result = this._nextPolicy.sendRequest(webResource);
+        void result.then((response) => {
+			this.logger.logResponse(response);
+		});
+		return result;
+	}
+}

--- a/src/utils/logging/msRest/MsRestNormalizer.ts
+++ b/src/utils/logging/msRest/MsRestNormalizer.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { HttpOperationResponse, WebResourceLike } from "@azure/ms-rest-js";
+import { HttpNormalizer, NormalizedHttpRequest, NormalizedHttpResponse } from "../HttpLogger";
+
+export class MsRestNormalizer implements HttpNormalizer<WebResourceLike, HttpOperationResponse> {
+    normalizeRequest(request: WebResourceLike): NormalizedHttpRequest {
+        return {
+            method: request.method,
+            url: request.url,
+            headers: request.headers.rawHeaders(),
+            query: request.query,
+            proxy: request.proxySettings ? {
+                password: request.proxySettings.password,
+                username: request.proxySettings.username,
+                host: request.proxySettings.host,
+                port: String(request.proxySettings.port),
+            } : undefined,
+        };
+    }
+
+    normalizeResponse(response: HttpOperationResponse): NormalizedHttpResponse {
+        return {
+            headers: response.headers.rawHeaders(),
+            request: this.normalizeRequest(response.request),
+            bodyAsText: response.bodyAsText ?? undefined,
+            status: response.status,
+        };
+    }
+}

--- a/src/utils/logging/nodeFetch/NodeFetchNormalizer.ts
+++ b/src/utils/logging/nodeFetch/NodeFetchNormalizer.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import type { Headers, Request, Response } from "node-fetch";
+import type { HttpNormalizer, NormalizedHttpRequest, NormalizedHttpResponse } from "../HttpLogger";
+
+type NodeFetchResponseInfo = {response: Response, request: Request, bodyAsText: string };
+
+export class NodeFetchNormalizer implements HttpNormalizer<Request, NodeFetchResponseInfo> {
+    normalizeRequest(request: Request): NormalizedHttpRequest {
+        return {
+            method: request.method,
+            url: request.url,
+            headers: this.convertNodeFetchHeaders(request.headers),
+        };
+    }
+
+    normalizeResponse(info: NodeFetchResponseInfo): NormalizedHttpResponse {
+        return {
+            request: this.normalizeRequest(info.request),
+            bodyAsText: info.bodyAsText,
+            status: info.response.status,
+            headers: this.convertNodeFetchHeaders(info.response.headers),
+        }
+    }
+
+    private convertNodeFetchHeaders(headers: Headers): Record<string, string> {
+        const headersRecord: Record<string, string> = {};
+        Object.entries(headers.raw()).forEach(([key, value]) => {
+            headersRecord[key] = value.join(', ');
+        });
+        return headersRecord;
+    }
+}

--- a/src/utils/logging/nodeFetch/nodeFetch.ts
+++ b/src/utils/logging/nodeFetch/nodeFetch.ts
@@ -1,0 +1,13 @@
+import fetch, { Request, RequestInfo, RequestInit, Response } from "node-fetch";
+import { ext } from "../../../extensionVariables";
+import { HttpLogger } from "../HttpLogger";
+import { NodeFetchNormalizer } from "./NodeFetchNormalizer";
+
+export async function fetchWithLogging(url: RequestInfo, init?: RequestInit): Promise<Response> {
+    const nodeFetchLogger = new HttpLogger(ext.outputChannel, 'NodeFetch', new NodeFetchNormalizer());
+    const request = new Request(url, init);
+    nodeFetchLogger.logRequest(request);
+    const response = await fetch(url, init);
+    nodeFetchLogger.logResponse({ response, request, bodyAsText: await response.text() });
+    return response;
+}

--- a/src/utils/logging/request/RequestNormalizer.ts
+++ b/src/utils/logging/request/RequestNormalizer.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as http from 'http';
+import * as request from 'request-promise';
+import type { HttpNormalizer, NormalizedHttpRequest, NormalizedHttpResponse } from "../HttpLogger";
+
+type RequestResponseInfo = { response: http.IncomingMessage & { body?: unknown }, request: request.Options };
+
+export class RequestNormalizer implements HttpNormalizer<request.Options, RequestResponseInfo> {
+    normalizeRequest(options: request.Options): NormalizedHttpRequest {
+        return { 
+            ...options, 
+            url: 'url' in options ? options.url.toString() : options.uri.toString() 
+        };
+    }
+
+    normalizeResponse(info: RequestResponseInfo): NormalizedHttpResponse {
+        return {
+            request: this.normalizeRequest(info.request),
+            status: info.response.statusCode,
+            headers: info.response.headers,
+            bodyAsText: 'body' in info.response ? JSON.stringify(info.response.body) : undefined,
+        }
+    }
+}

--- a/src/utils/logging/stringifyHttp.ts
+++ b/src/utils/logging/stringifyHttp.ts
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { NormalizedHttpRequest, NormalizedHttpResponse } from "./HttpLogger";
+
+export interface HttpStringifier {
+    stringifyRequest(request: NormalizedHttpRequest, source: string): string;
+    stringifyResponse(request: NormalizedHttpRequest, source: string): string;
+}
+
+/**
+ * @param request Request to log
+ * @param source Source of the request, ex: Axios
+ * @param verbose Logs the headers and query parameters if true
+ * @returns stringified request
+ */
+function stringifyRequest(request: NormalizedHttpRequest, source: string, verbose?: boolean): string {
+    let message = `[${source} Request]`;
+    message = `\n┌────── ${source} Request ${request.method} ${request.url}`;
+    if (verbose) {
+        message += stringifyRecord(request.headers ?? {}, 'Headers');
+        message += stringifyRecord(request.query ?? {}, 'Query parameters');
+    }
+    message += stringifyRecord(request.proxy ?? {}, 'Proxy configuration', true);
+    message += `\n└───────────────────────────────────────────────────`;
+    return message;
+}
+
+/**
+ * 
+ * @param response Response to log
+ * @param source Source of the response, ex: Axios
+ * @param hideBody Hides the body and prints the string instead
+ * @returns stringified request
+ */
+function stringifyResponse(response: NormalizedHttpResponse, source: string, hideBody?: string): string {
+    let message = `[${source} Response]`;
+    message += `\n┌────── ${source} Response ${response.request.method} - ${response.request.url}`;
+    message += stringifyRecord(response.headers ?? {}, 'Headers');
+    // only show the body if the log level is trace
+    message += `\n\tBody: ${hideBody ?? `\n\t${response.bodyAsText?.split('\n').join('\n\t')}`}`;
+    message += `\n└───────────────────────────────────────────────────`;
+    return message;
+}
+
+function stringifyRecord(record: Record<string, unknown>, label: string, hideCount?: boolean): string {
+    const entries = Object.entries(record).sort().filter(([_, value]) => typeof value !== 'object');
+    const entriesString = '\n\t└ ' + entries.map(([name, value]) => `${name}: "${Array.isArray(value) ? value.join(', ') : String(value)}"`).join('\n\t└ ');
+    return `\n\t${label}${entries.length && !hideCount ? ` (${entries.length})` : ''}:${entries.length === 0 ? ' None' : entriesString}`;
+}
+
+export class SimpleHttpStringifier implements HttpStringifier {
+    stringifyRequest(request: NormalizedHttpRequest, source: string): string {
+        return `[${source} Request] ${request.method} ${request.url}`;
+    }
+
+    stringifyResponse(response: NormalizedHttpResponse, source: string): string {
+        return `[${source} Response] ${response.status} - ${response.request.method} ${response.request.url}`;
+    }
+}
+
+export class DebugHttpStringifier implements HttpStringifier {
+    stringifyRequest(request: NormalizedHttpRequest, source: string): string {
+       return stringifyRequest(request, source, false);
+    }
+
+    stringifyResponse(response: NormalizedHttpResponse, source: string): string {
+        return stringifyResponse(response, source, "Hidden. Set log level to 'Trace' to see body.");
+    }
+
+    protected stringifyRecord(record: Record<string, unknown>, label: string, hideCount?: boolean): string {
+        const entries = Object.entries(record).sort().filter(([_, value]) => typeof value !== 'object');
+        const entriesString = '\n\t└ ' + entries.map(([name, value]) => `${name}: "${Array.isArray(value) ? value.join(', ') : String(value)}"`).join('\n\t└ ');
+        return `\n\t${label}${entries.length && !hideCount ? ` (${entries.length})` : ''}:${entries.length === 0 ? ' None' : entriesString}`;
+    }
+}
+
+export class TraceHttpStringifier implements HttpStringifier {
+    stringifyRequest(request: NormalizedHttpRequest, source: string): string {
+        return stringifyRequest(request, source, true);
+    }
+
+    stringifyResponse(response: NormalizedHttpResponse, source: string): string {
+        return stringifyResponse(response, source);
+    }
+}


### PR DESCRIPTION
MSAL and ADAL both have logging channels we can hook into, so I did that. For Http logging, there are 4+ http clients used in Azure Account, and I added normalizers for each of them. Until we add a feature that auto attaches logs to GH issues, we don't need to worry about masking. Although I am logging simpler HTTP messages when the log level is info, and logging more info when the log level is debug or trace.

I did some fancier things with the logs with the idea that we'll be able to use these in other extensions later on. Once we get around to adding logging to the other extension I'll move some of common classes to the utils package. Maybe we make a new package for logging? `@microsoft/vscode-azext-logging` 😄 