### PR TITLE
Clone response in logger

### DIFF
--- a/src/utils/logging/nodeFetch/nodeFetch.ts
+++ b/src/utils/logging/nodeFetch/nodeFetch.ts
@@ -8,6 +8,6 @@ export async function fetchWithLogging(url: RequestInfo, init?: RequestInit): Pr
     const request = new Request(url, init);
     nodeFetchLogger.logRequest(request);
     const response = await fetch(url, init);
-    nodeFetchLogger.logResponse({ response, request, bodyAsText: await response.text() });
+    nodeFetchLogger.logResponse({ response, request, bodyAsText: await response.clone().text() });
     return response;
 }


### PR DESCRIPTION
The underlying data is created using stream, which means you can only call `json` and `text` once, unless you clone it. We need to clone it here in case code outside the logger calls `json` or `text`.