### PR TITLE
Depend on Azure Resources extension for Cloud Shell feature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     },
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true,
-        "source.organizeImports": true
+        "source.fixAll.eslint": "explicit",
+        "source.organizeImports": "explicit"
     }
 }

--- a/package.json
+++ b/package.json
@@ -35,10 +35,7 @@
         "onCommand:azure-account.logout",
         "onCommand:azure-account.reportIssue",
         "onCommand:azure-account.selectSubscriptions",
-        "onCommand:azure-account.selectTenant",
-        "onCommand:azure-account.uploadFileCloudConsole",
-        "onTerminalProfile:azure-account.cloudShellBash",
-        "onTerminalProfile:azure-account.cloudShellPowerShell"
+        "onCommand:azure-account.selectTenant"
     ],
     "main": "./main",
     "contributes": {
@@ -87,11 +84,6 @@
                 "command": "azure-account.selectTenant",
                 "title": "%azure-account.commands.selectTenant%",
                 "category": "%azure-account.commands.azure%"
-            },
-            {
-                "command": "azure-account.uploadFileCloudConsole",
-                "title": "%azure-account.commands.uploadFileCloudConsole%",
-                "category": "%azure-account.commands.azure%"
             }
         ],
         "menus": {
@@ -99,24 +91,6 @@
                 {
                     "command": "azure-account.manageAccount",
                     "when": "never"
-                },
-                {
-                    "command": "azure-account.uploadFileCloudConsole",
-                    "when": "isWorkspaceTrusted"
-                }
-            ],
-            "explorer/context": [
-                {
-                    "command": "azure-account.uploadFileCloudConsole",
-                    "when": "resourceScheme == file && !explorerResourceIsFolder && isWorkspaceTrusted && openCloudConsoleCount && openCloudConsoleCount != 0",
-                    "group": "999_cloudConsole"
-                }
-            ],
-            "editor/title/context": [
-                {
-                    "command": "azure-account.uploadFileCloudConsole",
-                    "when": "resourceScheme == file && isWorkspaceTrusted && openCloudConsoleCount && openCloudConsoleCount != 0",
-                    "group": "999_cloudConsole"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -120,20 +120,6 @@
                 }
             ]
         },
-        "terminal": {
-            "profiles": [
-                {
-                    "title": "%azure-account.cloudShellBash%",
-                    "id": "azure-account.cloudShellBash",
-                    "icon": "azure"
-                },
-                {
-                    "title": "%azure-account.cloudShellPowerShell%",
-                    "id": "azure-account.cloudShellPowerShell",
-                    "icon": "azure"
-                }
-            ]
-        },
         "configuration": {
             "type": "object",
             "title": "Azure configuration",
@@ -334,5 +320,8 @@
         "uuid": "^8.3.2",
         "vscode-nls": "4.0.0",
         "ws": "^8.9.0"
-    }
+    },
+    "extensionDependencies": [
+        "ms-azuretools.vscode-azureresourcegroups"
+    ]
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,7 +1,5 @@
 {
     "azure-account.capabilities.untrustedWorkspaces.description": "Only global Azure configurations will be used when running in untrusted mode.",
-    "azure-account.cloudShellBash": "Azure Cloud Shell (Bash)",
-    "azure-account.cloudShellPowerShell": "Azure Cloud Shell (PowerShell)",
     "azure-account.commands.azure": "Azure",
     "azure-account.commands.azureAccount": "Azure Account",
     "azure-account.commands.createAccount": "Create an Account",

--- a/package.nls.json
+++ b/package.nls.json
@@ -10,6 +10,5 @@
     "azure-account.commands.manageAccount": "Manage Azure Account",
     "azure-account.commands.reportIssue": "Report Issue...",
     "azure-account.commands.selectSubscriptions": "Select Subscriptions",
-    "azure-account.commands.selectTenant": "Select Tenant",
-    "azure-account.commands.uploadFileCloudConsole": "Upload to Cloud Shell"
+    "azure-account.commands.selectTenant": "Select Tenant"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,11 +5,8 @@
 
 import { IActionContext, apiUtils, callWithTelemetryAndErrorHandling, createApiProvider, createAzExtLogOutputChannel, createExperimentationService, registerCommand, registerReportIssueCommand, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
 import axios from 'axios';
-import { createReadStream } from 'fs';
-import { basename } from 'path';
-import { ConfigurationTarget, ExtensionContext, ProgressLocation, Uri, WorkspaceConfiguration, env, window, workspace } from 'vscode';
+import { ConfigurationTarget, ExtensionContext, Uri, WorkspaceConfiguration, env, window, workspace } from 'vscode';
 import { AzureAccountExtensionApi } from './azure-account.api';
-import { OSName, OSes, shells } from './cloudConsole/cloudConsole';
 import { manageAccount } from './commands/manageAccount';
 import { cloudSetting, displayName, extensionPrefix, showSignedInEmailSetting } from './constants';
 import { ext } from './extensionVariables';
@@ -58,7 +55,6 @@ export async function activateInternal(context: ExtensionContext, perfStats: { l
 		registerCommand('azure-account.selectTenant', selectTenant);
 		registerCommand('azure-account.askForLogin', askForLogin);
 		registerCommand('azure-account.createAccount', createAccount);
-		registerCommand('azure-account.uploadFileCloudConsole', uploadFile);
 		registerCommand('azure-account.manageAccount', manageAccount);
 		context.subscriptions.push(ext.loginHelper.api.onSessionsChanged(updateSubscriptionsAndTenants));
 		context.subscriptions.push(ext.loginHelper.api.onSubscriptionsChanged(() => updateFilters()));
@@ -88,46 +84,6 @@ async function migrateEnvironmentSetting() {
 
 	await migrateSetting('Azure', 'AzureCloud');
 	await migrateSetting('AzureChina', 'AzureChinaCloud');
-}
-
-function cloudConsole(os: OSName) {
-	const shell = ext.loginHelper.api.createCloudShell(os);
-	if (shell) {
-		void shell.terminal.then(terminal => terminal.show());
-		return shell;
-	}
-}
-
-function uploadFile(_context: IActionContext, uri?: Uri) {
-	(async () => {
-		if (!workspace.isTrusted) {
-			throw new Error(localize('azure-account.uploadingRequiresTrustedWorkspace', 'File upload only works in a trusted workspace.'));
-		}
-		let shell = shells[0];
-		if (!shell) {
-			const shellName = await window.showInformationMessage(localize('azure-account.uploadingRequiresOpenCloudConsole', "File upload requires an open Cloud Shell."), OSes.Linux.shellName, OSes.Windows.shellName);
-			if (!shellName) {
-				return;
-			}
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			shell = cloudConsole(shellName === OSes.Linux.shellName ? 'Linux' : 'Windows')!;
-		}
-		if (!uri) {
-			uri = (await window.showOpenDialog({}) || [])[0];
-		}
-		if (uri) {
-			const filename = basename(uri.fsPath);
-			return window.withProgress({
-				location: ProgressLocation.Notification,
-				title: localize('azure-account.uploading', "Uploading '{0}'...", filename),
-				cancellable: true
-			}, (progress, token) => {
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-				return shell.uploadFile(filename, createReadStream(uri!.fsPath), { progress, token });
-			});
-		}
-	})()
-		.catch(logErrorMessage);
 }
 
 function logDiagnostics(context: ExtensionContext, api: AzureAccountExtensionApi) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,9 +7,9 @@ import { IActionContext, apiUtils, callWithTelemetryAndErrorHandling, createApiP
 import axios from 'axios';
 import { createReadStream } from 'fs';
 import { basename } from 'path';
-import { CancellationToken, ConfigurationTarget, ExtensionContext, ProgressLocation, Uri, WorkspaceConfiguration, env, window, workspace } from 'vscode';
+import { ConfigurationTarget, ExtensionContext, ProgressLocation, Uri, WorkspaceConfiguration, env, window, workspace } from 'vscode';
 import { AzureAccountExtensionApi } from './azure-account.api';
-import { OSName, OSes, createCloudConsole, shells } from './cloudConsole/cloudConsole';
+import { OSName, OSes, shells } from './cloudConsole/cloudConsole';
 import { manageAccount } from './commands/manageAccount';
 import { cloudSetting, displayName, extensionPrefix, showSignedInEmailSetting } from './constants';
 import { ext } from './extensionVariables';
@@ -63,17 +63,6 @@ export async function activateInternal(context: ExtensionContext, perfStats: { l
 		context.subscriptions.push(ext.loginHelper.api.onSessionsChanged(updateSubscriptionsAndTenants));
 		context.subscriptions.push(ext.loginHelper.api.onSubscriptionsChanged(() => updateFilters()));
 		registerReportIssueCommand('azure-account.reportIssue');
-
-		context.subscriptions.push(window.registerTerminalProfileProvider('azure-account.cloudShellBash', {
-			provideTerminalProfile: (token: CancellationToken) => {
-				return createCloudConsole(ext.loginHelper.api, 'Linux', token).terminalProfile;
-			}
-		}));
-		context.subscriptions.push(window.registerTerminalProfileProvider('azure-account.cloudShellPowerShell', {
-			provideTerminalProfile: (token: CancellationToken) => {
-				return createCloudConsole(ext.loginHelper.api, 'Windows', token).terminalProfile;
-			}
-		}));
 
 		survey(context);
 	});


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azureresourcegroups/pull/848

The idea is to make RGs an extension dependency so that users don't notice any UI changes. However, the entry point for cloud shell will now be contributed by RGs instead of Azure Account. This will be a great way to easily transition users to RGs.

Keeping the cloud shell code around because some extensions still rely on the API, which has yet to be migrated to RGs. One of which is https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureterraform

They can rely on AA until we figure out a solution